### PR TITLE
dedalo. add options for configure dns servers

### DIFF
--- a/dedalo/README.md
+++ b/dedalo/README.md
@@ -20,6 +20,7 @@ Available options:
 - ``HS_UUID``: a unique unit idenifier, usually a UUID, eg ``161fre6d-8578-4247-b4a2-c40dced94bdd``
 - ``HS_SECRET``: a shared secret between this unit and Icaro installation, eg: ``My$uperS3cret``
 - ``HS_ALLOW_ORIGIN``: hosts allowed to execute CORS requests to Dedalo, usually it corresponds to ``HS_SPLASH_PAGE_URL``, eg: ``http://icaro.mydomain.com``
+- ``HS_DNS1`` and ``HS_DNS2``: primary and secondary dns servers, if not sets, will be used the default servers (OpenDNS).
 - '`USE_UPDOWN_SCRIPTS`: flag for enable/disable use of dedalo's ipup and ipdown scripts.
 
 ### Example

--- a/dedalo/template/chilli.conf.tpl
+++ b/dedalo/template/chilli.conf.tpl
@@ -9,8 +9,8 @@ net             ${HS_NETWORK}
 dhcpif          ${HS_INTERFACE}
 tundev          tun-dedalo
 uamanydns
-dns1            "208.67.222.222"
-dns2            "208.67.220.220"
+dns1            "${HS_DNS1:-208.67.222.222}"
+dns2            "${HS_DNS2:-208.67.220.220}"
 uamport         3990
 locationname    "${HS_UNIT_NAME}"
 uamaaaurl       "${HS_AAA_URL}/?digest=${HS_DIGEST}&uuid=${HS_UUID}"


### PR DESCRIPTION
HS_DNS1 and HS_DNS2, if not sets, will be used the default dns servers
(OpenDNS).