### PR TITLE
dedalo & wax. Enable temporary sessions accounting

### DIFF
--- a/dedalo/www/temporary.chi
+++ b/dedalo/www/temporary.chi
@@ -52,7 +52,7 @@ then
 
 			http_header 200
 
-			dedalo query authorize mac "$REMOTE_MAC" sessiontimeout "$sessiontimeout" noacct
+			dedalo query authorize mac "$REMOTE_MAC" username "temporary" sessiontimeout "$sessiontimeout"
 
 		else
 			http_header 403

--- a/wax/methods/counters.go
+++ b/wax/methods/counters.go
@@ -173,14 +173,18 @@ func Counters(c *gin.Context, parameters url.Values) {
 
 	switch status {
 	case "start":
-		if strings.Compare(c.Query("user"), c.Query("mac")) == 0 {
-			//autologin
-			_, user := utils.GetUserByMacAddressAndunitMacAddress(c.Query("mac"), c.Query("ap"))
-			username = user.Username
+		if strings.Compare(c.Query("user"), "temporary") != 0 {
+			if strings.Compare(c.Query("user"), c.Query("mac")) == 0 {
+				//autologin
+				_, user := utils.GetUserByMacAddressAndunitMacAddress(c.Query("mac"), c.Query("ap"))
+				username = user.Username
+			} else {
+				username = c.Query("user")
+			}
+			Ack(c, startSession(username, c.Query("mac"), c.Query("ip"), c.Query("sessionid"), c.Query("nasid"), c.Query("ap")))
 		} else {
-			username = c.Query("user")
+			Ack(c, 1)
 		}
-		Ack(c, startSession(username, c.Query("mac"), c.Query("ip"), c.Query("sessionid"), c.Query("nasid"), c.Query("ap")))
 	case "stop":
 		Ack(c, stopSession(c.Query("sessionid"), c.Query("ap"), c.Query("bytes_down"), c.Query("bytes_up"), c.Query("duration")))
 	case "update":


### PR DESCRIPTION
Send accounting start also for temporary sessions from dedalo, but not saved by wax.