### PR TITLE
wax, config & deploy: Add url shortener service

### DIFF
--- a/deploy/ansible/roles/icarodb/files/icaro.sql
+++ b/deploy/ansible/roles/icarodb/files/icaro.sql
@@ -314,4 +314,15 @@ CREATE TABLE `hotspot_sms_counts` (
   FOREIGN KEY (`unit_id`) REFERENCES units(`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
   PRIMARY KEY(`id`)
 );
+
+/* -------------------- */
+
+/* URL SHORTENER */
+
+CREATE TABLE `short_urls` (
+  `id` serial,
+  `hash` varchar(200) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `long_url` varchar(2000) NOT NULL
+);
 /* ------ */

--- a/deploy/ansible/roles/wax/templates/wax-conf.j2
+++ b/deploy/ansible/roles/wax/templates/wax-conf.j2
@@ -66,5 +66,8 @@ icaro.wax.email_smtp_password is defined %}
             "link": "http://{{ icaro.hostname }}/wings/login/email"
 {% endif %}
         }
+    },
+    "shortener": {
+        "base_url": "https://{{ icaro.hostname }}/wax/short/"
     }
 }

--- a/sun/sun-api/configuration/configuration.go
+++ b/sun/sun-api/configuration/configuration.go
@@ -47,6 +47,7 @@ type Configuration struct {
 	TokenExpiresDays int               `json:"token_expires_days"`
 	RouteBlocked     models.AuthMaps   `json:"route_blocked"`
 	Endpoints        models.Endpoints  `json:"endpoints"`
+	Shortener        models.Shortener  `json:"shortener"`
 	Cors             struct {
 		Headers []string `json:"headers"`
 		Origins []string `json:"origins"`
@@ -164,6 +165,10 @@ func Init(ConfigFilePtr *string) {
 	}
 	if os.Getenv("EMAIL_LOGIN_LINK") != "" {
 		Config.Endpoints.Email.Link = os.Getenv("EMAIL_LOGIN_LINK")
+	}
+
+	if os.Getenv("SHORTENER_BASE_URL") != "" {
+		Config.Shortener.BaseUrl = os.Getenv("SHORTENER_BASE_URL")
 	}
 
 	if os.Getenv("CAPTIVE_REDIRECT") != "" {

--- a/sun/sun-api/models/short_url.go
+++ b/sun/sun-api/models/short_url.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package models
+
+import "time"
+
+type ShortUrl struct {
+	Id        int       `db:"id" json:"id"`
+	Hash      string    `db:"hash" json:"hash"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	LongUrl   string    `db:"long_url" json:"long_url"`
+}

--- a/sun/sun-api/models/shortener.go
+++ b/sun/sun-api/models/shortener.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package models
+
+type Shortener struct {
+	BaseUrl string `json:"base_url"`
+}

--- a/wax/main.go
+++ b/wax/main.go
@@ -51,6 +51,8 @@ func DefineAPI(router *gin.Engine) {
 	privacy := wax.Group("/privacy")
 	privacy.GET("/:hotspot_uuid", methods.GetPrivacies)
 
+	wax.GET("/short/:hash", methods.GetLongUrl)
+
 	wax.Use(middleware.WaxWall)
 	{
 		// handle AAA requests

--- a/wax/methods/shortener.go
+++ b/wax/methods/shortener.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ * author: Matteo Valentini <matteo.valentini@nethesis.it>
+ */
+
+package methods
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nethesis/icaro/wax/utils"
+)
+
+func GetLongUrl(c *gin.Context) {
+	hash := c.Param("hash")
+
+	shortUrl := utils.GetShortUrlByHash(hash)
+
+	if shortUrl.Id > 0 {
+		c.Redirect(http.StatusFound, shortUrl.LongUrl)
+		return
+	} else {
+		c.JSON(http.StatusNotFound, gin.H{"message": "Shortener hash not found!"})
+		return
+	}
+}


### PR DESCRIPTION
Use url shortener for reduce the lenght of the login link send by sms
message when the user select sms authentication.
Shortener steps:
	1) Calculate a sha-1 hash of the original url
	2) Take only the first 7 digit of the hash
	3) Encode the 7 digits in base 64(url safe and without padding)
	4) Concatenate the string with the `shortener.base_url` option, for
	   generate the short url.
When the short url it's called, will be redirect to the longer url.