### PR TITLE
Add dhcp range support to dedalo 

### DIFF
--- a/dedalo/README.md
+++ b/dedalo/README.md
@@ -19,6 +19,8 @@ Available options:
 - ``HS_UNIT_DESC``: a descriptive name of local installation, eg: ``MyHotelAtTheSea``
 - ``HS_UUID``: a unique unit idenifier, usually a UUID, eg ``161fre6d-8578-4247-b4a2-c40dced94bdd``
 - ``HS_SECRET``: a shared secret between this unit and Icaro installation, eg: ``My$uperS3cret``
+- ``HS_DHCPSTART``: last octet of the start ip address of dhcp range, eg: 192.168.182.10 this value should be ``10``.Note that the first ip of the hotspot network is hold by the hotspot service and can't be assigned. (default 10)
+- ``HS_DHCPEND``: last octet of the last ip address of dhcp range, eg: 192.168.182.55 this value should be only ``55``. (default 254)
 - ``HS_ALLOW_ORIGIN``: hosts allowed to execute CORS requests to Dedalo, usually it corresponds to ``HS_SPLASH_PAGE_URL``, eg: ``http://icaro.mydomain.com``
 - ``HS_DNS1`` and ``HS_DNS2``: primary and secondary dns servers, if not sets, will be used the default servers (OpenDNS).
 - '`USE_UPDOWN_SCRIPTS`: flag for enable/disable use of dedalo's ipup and ipdown scripts.
@@ -34,6 +36,8 @@ HS_UNIT_NAME="unit-king"
 HS_UNIT_DESC="unit-desc"
 HS_UUID="1610fe6d-8578-4247-b4a2-c40dced94ber"
 HS_SECRET="My__Secret99"
+HS_DHCPSTART=10
+HS_DHCPEND=55
 HS_ALLOW_ORIGINS="*"
 USE_UPDOWN_SCRIPTS=true
 ```

--- a/dedalo/dist/dedalo.spec
+++ b/dedalo/dist/dedalo.spec
@@ -1,5 +1,5 @@
 Name: dedalo
-Version: 0.2.1
+Version: 0.2.2
 Release: 1%{?dist}
 Summary: Network Access Controller, runs on the firewall and intercepts all guest connections
 
@@ -64,6 +64,9 @@ touch %{buildroot}/opt/icaro/dedalo/walled_gardens/local.conf
 
 
 %changelog
+* Mon Mar 25 2019 Matteo Valentini <matteo.valentini@nethesis.it> - 0.2.2-1
+  - dedalo. add dhcp range support
+
 * Tue Jun 05 2018 Matteo Valentini <matteo.valentini@nethesis.it> - 0.2.1-1
 - sun, wax & dedalo. implemented traffic and time limit for users, api side
 

--- a/dedalo/template/chilli.conf.tpl
+++ b/dedalo/template/chilli.conf.tpl
@@ -18,6 +18,8 @@ radiusserver1   "localhost"
 uamserver       "${HS_SPLASH_PAGE_URL}/?digest=${HS_DIGEST}&uuid=${HS_UUID}&timezone=${HS_TIMEZONE}"
 radiusnasid     "${HS_ID}"
 alloworigin     "${HS_ALLOW_ORIGINS}"
+${HS_DHCPSTART:+"dhcpstart  $HS_DHCPSTART"}
+${HS_DHCPEND:+"dhcpend  $HS_DHCPEND"}
 macauth
 
 uamdomain       "${HS_AAA_HOST}"


### PR DESCRIPTION
Allow specify a dhcp different from the whole network used by default.