### PR TITLE
Delay of feedback email in minutes instead of hours

### DIFF
--- a/ade/ade-tasks/tasks/tasks.go
+++ b/ade/ade-tasks/tasks/tasks.go
@@ -42,10 +42,10 @@ func Init(action string, worker bool) {
 	switch action {
 
 	case "send-surveys":
-		c.AddFunc("@every 1h", sendSurveysActive)
+		c.AddFunc("@every 1m", sendSurveysActive)
 		sendSurveysActive()
 	case "send-surveys-expired":
-		c.AddFunc("@every 1h", sendSurveysExpired)
+		c.AddFunc("@every 1m", sendSurveysExpired)
 		sendSurveysExpired()
 
 	default:
@@ -179,7 +179,7 @@ func sendSurveys(users []User) {
 				if marketingFirstEmail.Value == "true" {
 					// check if time to send
 					marketingFirstAfterInt, _ := strconv.Atoi(marketingFirstAfter.Value)
-					if adeToken.FeedbackSentTime.IsZero() && u.ValidFrom.Add(time.Duration(marketingFirstAfterInt)*time.Hour).Before(time.Now()) {
+					if adeToken.FeedbackSentTime.IsZero() && u.ValidFrom.Add(time.Duration(marketingFirstAfterInt)*time.Minute).Before(time.Now()) {
 						// send mail
 						if len(u.Email) > 0 {
 							utils.SendFeedBackMessageToUser(adeToken, u.Email, hotspotName.Value, hotspotLogo.Value, hotspotBg.Value, hotspot, hotspotFeedbackBodyText.Value)

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -343,7 +343,7 @@
       "email_feedback": "Service manager email address",
       "email_first": "Request support feedback",
       "email_second": "Request review feedback",
-      "email_first_after": "Request feedback after (hours)",
+      "email_first_after": "Request feedback after (minutes)",
       "email_first_template": "Feedback email text",
       "email_first_template_preview": "Feedback email preview",
       "email_second_template": "Review email text",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -343,7 +343,7 @@
       "email_feedback": "Indirizzo email per le segnalazioni",
       "email_first": "Invia richiesta assistenza",
       "email_second": "Invia richiesta recensione",
-      "email_first_after": "Invia richiesta dopo (ore)",
+      "email_first_after": "Invia richiesta dopo (minuti)",
       "email_first_template": "Testo email di richiesta assistenza",
       "email_first_template_preview": "Anteprima",
       "email_second_template": "Testo email di richiesta recensione",


### PR DESCRIPTION
Set delay of automatic sending of feedback email in minutes instead of hours.

**NOTE**: before the release the preexisting values on the database must be converted in minutes with the following query:

```
UPDATE hotspot_preferences
SET value=CAST((CONVERT(value, UNSIGNED INTEGER) * 60) AS CHAR(50))
WHERE `key`='marketing_6_first_after';
```

https://github.com/nethesis/dev/issues/5706