### PR TITLE
Wax: fixed email and SMS login with voucher expired

### DIFF
--- a/wax/methods/auth_others.go
+++ b/wax/methods/auth_others.go
@@ -161,7 +161,12 @@ func SMSAuth(c *gin.Context) {
 			voucher := utils.GetVoucherByCode(voucherCode, user.HotspotId)
 
 			if voucher.Id > 0 {
-				user.ValidUntil = time.Now().UTC().AddDate(0, 0, voucher.Duration)
+				duration := voucher.Duration
+
+				if duration == 0 {
+					duration = int(voucher.Expires.Sub(time.Now().UTC()).Hours()/24) + 1
+				}
+				user.ValidUntil = time.Now().UTC().AddDate(0, 0, duration)
 				user.KbpsDown = voucher.BandwidthDown
 				user.KbpsUp = voucher.BandwidthUp
 				user.AutoLogin = voucher.AutoLogin
@@ -316,7 +321,12 @@ func EmailAuth(c *gin.Context) {
 			voucher := utils.GetVoucherByCode(voucherCode, user.HotspotId)
 
 			if voucher.Id > 0 {
-				user.ValidUntil = time.Now().UTC().AddDate(0, 0, voucher.Duration)
+				duration := voucher.Duration
+
+				if duration == 0 {
+					duration = int(voucher.Expires.Sub(time.Now().UTC()).Hours()/24) + 1
+				}
+				user.ValidUntil = time.Now().UTC().AddDate(0, 0, duration)
 				user.KbpsDown = voucher.BandwidthDown
 				user.KbpsUp = voucher.BandwidthUp
 				user.AutoLogin = voucher.AutoLogin


### PR DESCRIPTION
Fixed email and SMS login with voucher block expired.
This bug happened only with vouchers having expiration date (not duration).

https://github.com/nethesis/dev/issues/5706