### PR TITLE
Custom privacy and TOS disclaimers

### DIFF
--- a/deploy/ansible/roles/icarodb/files/icaro.sql
+++ b/deploy/ansible/roles/icarodb/files/icaro.sql
@@ -403,4 +403,42 @@ CREATE TABLE `hotspot_integrations` (
   UNIQUE KEY (`hotspot_id`, `integration_id`),
   PRIMARY KEY(`id`)
 );
+
+/* ------------ */
+
+/* CUSTOM DISCLAIMERS */
+
+CREATE TABLE `disclaimers` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(250) NOT NULL,
+  `title` varchar(250) NOT NULL,
+  `body` text NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`)
+);
+
+CREATE TABLE `disclaimers_hotspots` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `disclaimer_id` bigint(20) unsigned NOT NULL,
+  `hotspot_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`),
+  KEY `hotspot_id` (`hotspot_id`),
+  KEY `disclaimer_id` (`disclaimer_id`,`hotspot_id`),
+  CONSTRAINT `disclaimers_hotspots_ibfk_1` FOREIGN KEY (`disclaimer_id`) REFERENCES `disclaimers` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `disclaimers_hotspots_ibfk_2` FOREIGN KEY (`hotspot_id`) REFERENCES `hotspots` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE TABLE `disclaimers_accounts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `disclaimer_id` bigint(20) unsigned NOT NULL,
+  `account_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`),
+  KEY `account_id` (`account_id`),
+  KEY `disclaimer_id` (`disclaimer_id`,`account_id`),
+  CONSTRAINT `disclaimers_accounts_ibfk_1` FOREIGN KEY (`disclaimer_id`) REFERENCES `disclaimers` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `disclaimers_accounts_ibfk_2` FOREIGN KEY (`account_id`) REFERENCES `accounts` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
 /* ------------ */

--- a/sun/sun-api/main.go
+++ b/sun/sun-api/main.go
@@ -107,8 +107,8 @@ func DefineAPI(router *gin.Engine) {
 		preferences := api.Group("/preferences")
 		{
 			resellersPref := preferences.Group("/accounts")
-			resellersPref.GET("", methods.GetAccountPrefs)
-			resellersPref.PUT("", methods.UpdateAccountPrefs)
+			resellersPref.GET("/:account_id", methods.GetAccountPrefs)
+			resellersPref.PUT("/:account_id", methods.UpdateAccountPrefs)
 
 			hotspotsPref := preferences.Group("/hotspots")
 			hotspotsPref.GET("/:hotspot_id", methods.GetHotspotPrefs)
@@ -203,6 +203,15 @@ func DefineAPI(router *gin.Engine) {
 		subscriptionsPlans := api.Group("/subscription_plans")
 		{
 			subscriptionsPlans.GET("/", methods.GetSubscriptionPlans)
+		}
+
+		disclaimers := api.Group("/disclaimers")
+		{
+			disclaimers.DELETE("/:disclaimer_id", methods.DeleteDisclaimer)
+
+			accountsDisclaimers := disclaimers.Group("/accounts")
+			accountsDisclaimers.GET("/:account_id", methods.GetAccountDisclaimers)
+			accountsDisclaimers.POST("/:account_id", methods.CreateAccountDisclaimer)
 		}
 	}
 

--- a/sun/sun-api/methods/disclaimers.go
+++ b/sun/sun-api/methods/disclaimers.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2020 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ */
+
+package methods
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+	"github.com/nethesis/icaro/sun/sun-api/database"
+	"github.com/nethesis/icaro/sun/sun-api/models"
+)
+
+func GetAccountDisclaimers(c *gin.Context) {
+	var disclaimers []models.Disclaimer
+	accountId := c.MustGet("token").(models.AccessToken).AccountId
+	db := database.Instance()
+	queryAccountId := accountId
+
+	if accountId == 1 {
+		queryAccountId, _ = strconv.Atoi(c.Param("account_id"))
+	}
+
+	selectQuery := "disclaimers.*"
+	joinQuery := "JOIN disclaimers_accounts on disclaimers_accounts.disclaimer_id = disclaimers.id"
+	db.Select(selectQuery).Joins(joinQuery).Where("disclaimers_accounts.account_id = ?", queryAccountId).Find(&disclaimers)
+
+	if len(disclaimers) <= 0 {
+		c.JSON(http.StatusNotFound, gin.H{"message": "No disclaimer found"})
+		return
+	}
+	c.JSON(http.StatusOK, disclaimers)
+}
+
+func DeleteDisclaimer(c *gin.Context) {
+	accountId := c.MustGet("token").(models.AccessToken).AccountId
+
+	if accountId != 1 {
+		c.JSON(http.StatusForbidden, gin.H{"message": "Operation not permitted!"})
+		return
+	}
+
+	var disclaimer models.Disclaimer
+	disclaimerId := c.Param("disclaimer_id")
+	db := database.Instance()
+	db.Where("id = ?", disclaimerId).First(&disclaimer)
+
+	if disclaimer.Id == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"message": "No disclaimer found!"})
+		return
+	}
+
+	db.Delete(&disclaimer)
+	c.JSON(http.StatusOK, gin.H{"status": "success"})
+}
+
+func CreateAccountDisclaimer(c *gin.Context) {
+	accountId := c.MustGet("token").(models.AccessToken).AccountId
+
+	if accountId != 1 {
+		c.JSON(http.StatusForbidden, gin.H{"message": "Operation not permitted!"})
+		return
+	}
+
+	var json models.Disclaimer
+	if err := c.BindJSON(&json); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Request fields malformed", "error": err.Error()})
+		return
+	}
+
+	// create disclaimer
+
+	disclaimer := models.Disclaimer{
+		Type:  json.Type,
+		Title: json.Title,
+		Body:  json.Body,
+	}
+
+	db := database.Instance()
+	db.Save(&disclaimer)
+
+	if disclaimer.Id == 0 {
+		c.JSON(http.StatusConflict, gin.H{"disclaimer_id": disclaimer.Id, "status": "disclaimer already exists"})
+	}
+
+	// associate disclaimer to account
+
+	accountId, _ = strconv.Atoi(c.Param("account_id"))
+
+	disclaimersAccounts := models.DisclaimersAccounts{
+		DisclaimerId: disclaimer.Id,
+		AccountId:    accountId,
+	}
+
+	db.Save(&disclaimersAccounts)
+
+	if disclaimersAccounts.Id == 0 {
+		c.JSON(http.StatusConflict, gin.H{"disclaimers_accounts_id": disclaimersAccounts.Id, "status": "disclaimers_accounts already exists"})
+	} else {
+		c.JSON(http.StatusCreated, gin.H{"disclaimer_id": disclaimer.Id, "disclaimers_accounts_id": disclaimersAccounts.Id, "status": "success"})
+	}
+}

--- a/sun/sun-api/models/disclaimer.go
+++ b/sun/sun-api/models/disclaimer.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ */
+
+package models
+
+type Disclaimer struct {
+	Id    int    `db:"id" json:"id"`
+	Type  string `db:"type" json:"type"`
+	Title string `db:"title" json:"title"`
+	Body  string `db:"body" json:"body"`
+}

--- a/sun/sun-api/models/disclaimers_accounts.go
+++ b/sun/sun-api/models/disclaimers_accounts.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ */
+
+package models
+
+type DisclaimersAccounts struct {
+	Id           int `db:"id" json:"id"`
+	DisclaimerId int `db:"disclaimer_id" json:"disclaimer_id"`
+	AccountId    int `db:"account_id" json:"account_id"`
+}

--- a/sun/sun-api/models/disclaimers_hotspots.go
+++ b/sun/sun-api/models/disclaimers_hotspots.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Icaro project.
+ *
+ * Icaro is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Icaro is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Icaro.  If not, see COPYING.
+ *
+ */
+
+package models
+
+type DisclaimersHotspots struct {
+	Id           int `db:"id" json:"id"`
+	DisclaimerId int `db:"disclaimer_id" json:"disclaimer_id"`
+	HotspotId    int `db:"hotspot_id" json:"hotspot_id"`
+}

--- a/sun/sun-api/models/hotspot.go
+++ b/sun/sun-api/models/hotspot.go
@@ -25,19 +25,21 @@ package models
 import "time"
 
 type Hotspot struct {
-	Id               int       `db:"id" json:"id"`
-	Uuid             string    `db:"uuid" json:"uuid"`
-	AccountId        int       `db:"account_id" json:"account_id"`
-	Name             string    `db:"name" json:"name"`
-	Description      string    `db:"description" json:"description"`
-	BusinessName     string    `db:"business_name" json:"business_name"`
-	BusinessVAT      string    `db:"business_vat" json:"business_vat"`
-	BusinessAddress  string    `db:"business_address" json:"business_address"`
-	BusinessEmail    string    `db:"business_email" json:"business_email"`
-	BusinessDPO      string    `db:"business_dpo" json:"business_dpo"`
-	BusinessDPOMail  string    `db:"business_dpo_mail" json:"business_dpo_mail"`
-	IntegrationTerms string    `db:"integration_terms" json:"-"`
-	Created          time.Time `db:"created" json:"created"`
+	Id                  int       `db:"id" json:"id"`
+	Uuid                string    `db:"uuid" json:"uuid"`
+	AccountId           int       `db:"account_id" json:"account_id"`
+	Name                string    `db:"name" json:"name"`
+	Description         string    `db:"description" json:"description"`
+	BusinessName        string    `db:"business_name" json:"business_name"`
+	BusinessVAT         string    `db:"business_vat" json:"business_vat"`
+	BusinessAddress     string    `db:"business_address" json:"business_address"`
+	BusinessEmail       string    `db:"business_email" json:"business_email"`
+	BusinessDPO         string    `db:"business_dpo" json:"business_dpo"`
+	BusinessDPOMail     string    `db:"business_dpo_mail" json:"business_dpo_mail"`
+	IntegrationTerms    string    `db:"integration_terms" json:"-"`
+	Created             time.Time `db:"created" json:"created"`
+	PrivacyDisclaimerId int       `gorm:"-" json:"privacy_disclaimer_id"`
+	TosDisclaimerId     int       `gorm:"-" json:"tos_disclaimer_id"`
 
 	Account Account `gorm:"PRELOAD:false json:"account"`
 }

--- a/sun/sun-ui/src/components/Profile.vue
+++ b/sun/sun-ui/src/components/Profile.vue
@@ -72,6 +72,58 @@
           </div>
         </div>
       </div>
+      <!-- disclaimer -->
+      <div
+        v-if="disclaimers.data && disclaimers.data.length"
+        class="col-xs-12 col-sm-12 col-md-6"
+      >
+        <div class="card-pf card-pf-accented">
+          <div class="card-pf-heading">
+            <h2 class="card-pf-title">
+              {{ $t("profile.default_disclaimer") }}
+              <div v-if="!disclaimers.isLoading" class="pficon pficon-catalog card-info-title right"></div>
+              <div v-if="disclaimers.isLoading" class="spinner spinner-sm right"></div>
+            </h2>
+          </div>
+          <div v-if="!disclaimers.isLoading" class="card-pf-body">
+            <form class="form-horizontal" role="form">
+              <div class="form-group">
+                <label class="col-sm-4 control-label">{{ $t("profile.privacy_disclaimer") }}</label>
+                <div class="col-sm-8">
+                  <select v-model="disclaimers.preferredPrivacyDisclaimerId" class="form-control">
+                    <option value="">{{ $t("profile.default") }}</option>
+                    <option v-for="privacyDisclaimer in disclaimers.privacyDisclaimers" :key="privacyDisclaimer.id" :value="privacyDisclaimer.id">
+                      {{ privacyDisclaimer.title }}
+                    </option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-4 control-label">{{ $t("profile.tos_disclaimer") }}</label>
+                <div class="col-sm-8">
+                  <select v-model="disclaimers.preferredTosDisclaimerId" class="form-control">
+                    <option value="">{{ $t("profile.default") }}</option>
+                    <option v-for="tosDisclaimer in disclaimers.tosDisclaimers" :key="tosDisclaimer.id" :value="tosDisclaimer.id">
+                      {{ tosDisclaimer.title }}
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="card-pf-footer">
+            <div class="dropdown card-pf-time-frame-filter">
+              <span v-if="disclaimers.updateError" class="pficon pficon-error-circle-o bigger update-pref-feedback"></span>
+              <span v-if="disclaimers.updateSuccess" class="pficon pficon-ok update-pref-feedback"></span>
+              <button class="btn btn-default" v-on:click="updateDisclaimers()">{{ $t("update") }}</button>
+            </div>
+            <p>
+              <a href="#" class="card-pf-link-with-icon">
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="modal fade" id="changePassModal" tabindex="-1" role="dialog" aria-labelledby="changePassModalLabel" aria-hidden="true">
@@ -125,10 +177,12 @@ import LoginService from "../services/login";
 import StorageService from "../services/storage";
 import UtilService from "../services/util";
 import StatsService from "../services/stats";
+import DisclaimerService from "../services/disclaimer";
+import PreferenceService from "../services/preference";
 
 export default {
   name: "Profile",
-  mixins: [LoginService, StorageService, UtilService, StatsService],
+  mixins: [LoginService, StorageService, UtilService, StatsService, DisclaimerService, PreferenceService],
   data() {
     return {
       msg: this.$i18n.t("menu.profile"),
@@ -146,10 +200,21 @@ export default {
         isLoading: true,
         data: {}
       },
+      disclaimers: {
+        data: {},
+        isLoading: true,
+        preferredPrivacyDisclaimerId: "",
+        preferredTosDisclaimerId: "",
+        privacyDisclaimers: [],
+        tosDisclaimers: [],
+        updateSuccess: false,
+        updateError: false,
+      },
     };
   },
   mounted() {
     this.getSmsThreshold();
+    this.getDisclaimers();
   },
   methods: {
     changePassword() {
@@ -199,11 +264,88 @@ export default {
           console.error(error.body);
         }
       );
+    },
+    getDisclaimers() {
+      this.disclaimersByAccount(
+        this.user.login.id,
+        success => {
+          this.disclaimers.data = success.body;
+          this.privacy_disclaimers = [];
+          this.tos_disclaimers = [];
+
+          this.disclaimers.data.forEach((disclaimer) => {
+            if (disclaimer.type === "privacy") {
+              this.disclaimers.privacyDisclaimers.push(disclaimer);
+            } else {
+              this.disclaimers.tosDisclaimers.push(disclaimer);
+            }
+          });
+          this.getPreferredDisclaimers();
+        },
+        error => {
+          this.disclaimers.isLoading = false;
+          console.error(error.body);
+        }
+      );
+    },
+    getPreferredDisclaimers() {
+      this.accountPrefGet(
+        this.user.login.id,
+        success => {
+          this.disclaimers.preferredPrivacyDisclaimerId = "";
+          this.disclaimers.preferredTosDisclaimerId = "";
+
+          success.body.forEach((pref) => {
+            if (pref.key === "custom_disclaimers_privacy") {
+              this.disclaimers.preferredPrivacyDisclaimerId = pref.value;
+            } else if (pref.key === "custom_disclaimers_terms") {
+              this.disclaimers.preferredTosDisclaimerId = pref.value;
+            }
+          });
+          this.disclaimers.isLoading = false;
+        },
+        error => {
+          this.disclaimers.isLoading = false;
+          console.error(error.body);
+        }
+      );
+    },
+    updateDisclaimers() {
+      this.updateDisclaimer("custom_disclaimers_privacy", this.disclaimers.preferredPrivacyDisclaimerId);
+      this.updateDisclaimer("custom_disclaimers_terms", this.disclaimers.preferredTosDisclaimerId);
+    },
+    updateDisclaimer(prefKey, prefValue) {
+      this.accountPrefModify(
+        this.user.login.id,
+        {
+          key: prefKey,
+          value: prefValue.toString(),
+          account_id: this.user.login.id,
+        },
+        success => {
+          this.disclaimers.updateSuccess = true;
+          setTimeout(() => {
+            this.disclaimers.updateSuccess = false;
+          }, 2000);
+        },
+        error => {
+          console.error(error.body);
+
+          this.disclaimers.updateError = true;
+          setTimeout(() => {
+            this.disclaimers.updateError = false;
+          }, 2000);
+        }
+      );
     }
   }
 };
 </script>
 
 <style>
-
+.update-pref-feedback {
+  vertical-align: middle;
+  margin-right: 0.4em;
+  font-size: 140%;
+}
 </style>

--- a/sun/sun-ui/src/directives/HotspotAction.vue
+++ b/sun/sun-ui/src/directives/HotspotAction.vue
@@ -86,6 +86,34 @@
                   <input v-model="currentObj.business_dpo_mail" type="email" id="textInput2-modal-markup" class="form-control" :placeholder="$t('hotspot.business_dpo_mail')">
                 </div>
               </div>
+              <!-- privacy disclaimer -->
+              <div v-if="disclaimers.privacyDisclaimers && disclaimers.privacyDisclaimers.length > 1" class="form-group">
+                <label
+                  class="col-sm-4 control-label"
+                  for="textInput2-modal-markup"
+                >{{ $t("hotspot.privacy_disclaimer") }}</label>
+                <div class="col-sm-8">
+                  <select v-model="disclaimers.currentPrivacyDisclaimerId" class="form-control">
+                    <option v-for="privacyDisclaimer in disclaimers.privacyDisclaimers" :key="privacyDisclaimer.id" :value="privacyDisclaimer.id">
+                      {{ privacyDisclaimer.title }}
+                    </option>
+                  </select>
+                </div>
+              </div>
+              <!-- tos disclaimer -->
+              <div v-if="disclaimers.tosDisclaimers && disclaimers.tosDisclaimers.length > 1" class="form-group">
+                <label
+                  class="col-sm-4 control-label"
+                  for="textInput2-modal-markup"
+                >{{ $t("hotspot.tos_disclaimer") }}</label>
+                <div class="col-sm-8">
+                  <select v-model="disclaimers.currentTosDisclaimerId" class="form-control">
+                    <option v-for="tosDisclaimer in disclaimers.tosDisclaimers" :key="tosDisclaimer.id" :value="tosDisclaimer.id">
+                      {{ tosDisclaimer.title }}
+                    </option>
+                  </select>
+                </div>
+              </div>
               <div v-if="errors.update" class="alert alert-danger alert-dismissable">
                 <span class="pficon pficon-error-circle-o"></span>
                 <strong>{{ $t("hotspot.update_error_title") }}</strong>. {{ $t("hotspot.update_error_sub") }}.
@@ -147,15 +175,23 @@ export default {
     };
     return {
       errors: errors,
-      currentObj: currentObj
+      currentObj: currentObj,
+      disclaimers: {
+        currentPrivacyDisclaimerId: 0,
+        currentTosDisclaimerId: 0,
+        privacyDisclaimers: [],
+        tosDisclaimers: [],
+      },
     };
   },
   methods: {
     setCurrentObj(obj) {
       this.currentObj = Object.assign({}, obj);
+      this.getPrivacyInfo(this.currentObj.uuid);
     },
     modifyHotspot(obj) {
       this.currentObj.onAction = true;
+
       this.hotspotModify(
         obj.id,
         {
@@ -165,7 +201,9 @@ export default {
           business_address: obj.business_address,
           business_email: obj.business_email,
           business_dpo: obj.business_dpo,
-          business_dpo_mail: obj.business_dpo_mail
+          business_dpo_mail: obj.business_dpo_mail,
+          privacy_disclaimer_id: this.disclaimers.currentPrivacyDisclaimerId ? parseInt(this.disclaimers.currentPrivacyDisclaimerId) : 0,
+          tos_disclaimer_id: this.disclaimers.currentTosDisclaimerId ? parseInt(this.disclaimers.currentTosDisclaimerId) : 0
         },
         success => {
           this.currentObj.onAction = false;
@@ -197,7 +235,22 @@ export default {
           console.error(error.body.message);
         }
       );
-    }
+    },
+    getPrivacyInfo(uuid) {
+      this.hotspotPrivacy(
+        uuid,
+        success => {
+          this.disclaimers.privacyDisclaimers = success.body.privacy_disclaimers;
+          this.disclaimers.tosDisclaimers = success.body.tos_disclaimers;
+          this.disclaimers.currentPrivacyDisclaimerId = success.body.privacy_selected_id;
+          this.disclaimers.currentTosDisclaimerId = success.body.tos_selected_id;
+          this.$forceUpdate();
+        },
+        error => {
+          console.error(error.body);
+        }
+      );
+    },
   }
 };
 </script>

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -36,7 +36,11 @@
       "change_password_error_sub": "Something went wrong on changing password",
       "sms": "SMS",
       "sms_login_threshold": "Warning threshold",
-      "sms_threshold_description": "You'll receive an email when the number of remaining SMS will be lower than the warning threshold"
+      "sms_threshold_description": "You'll receive an email when the number of remaining SMS will be lower than the warning threshold",
+      "default_disclaimer": "Default disclaimers",
+      "privacy_disclaimer": "Privacy disclaimer",
+      "tos_disclaimer": "Terms of use disclaimer",
+      "default": "Default"
     },
     "hotspot": {
       "yes": "Yes",
@@ -171,7 +175,10 @@
       "create_voucher_custom": "Create custom voucher",
       "voucher_custom_code": "Code",
       "i_agree": "I agree to the general user conditions",
-      "tos_and_privacy": "ToS and Privacy"
+      "tos_and_privacy": "ToS and Privacy",
+      "privacy_disclaimer": "Privacy disclaimer",
+      "tos_disclaimer": "Terms of use disclaimer",
+      "disclaimer_default": "Default"
     },
     "user": {
       "username": "Username",
@@ -248,7 +255,18 @@
       "site": "Site",
       "enable": "Enable",
       "disable": "Disable",
-      "integration": "Integration"
+      "integration": "Integration",
+      "add_disclaimer": "Add disclaimer",
+      "no_disclaimer": "No disclaimer",
+      "disclaimers": "Disclaimers",
+      "disclaimer_title": "Name",
+      "disclaimer_type": "Type",
+      "disclaimer_body": "Text",
+      "privacy": "Privacy",
+      "tos": "Terms of Use",
+      "add": "Add",
+      "delete_disclaimer": "Delete disclaimer",
+      "delete_disclaimer_confirm": "You are about to delete disclaimer"
     },
     "unit": {
       "unit": "Unit",
@@ -448,6 +466,8 @@
     "upload_file_not_supported": "File not supported",
     "upload_file_exceed": "File limit exceed (max 700 KB)",
     "result": "result",
-    "results": "results"
+    "results": "results",
+    "are_you_sure": "Are you sure",
+    "warning": "Warning"
   }
 }

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -36,7 +36,11 @@
       "change_password_error_sub": "Ci sono stati problemi durante il cambio password, contatta il tuo amministratore.",
       "sms": "SMS",
       "sms_login_threshold": "Soglia di avviso",
-      "sms_threshold_description": "Si riceverà una notifica email quando il numero di SMS rimanenti sarà inferiore alla soglia di avviso"
+      "sms_threshold_description": "Si riceverà una notifica email quando il numero di SMS rimanenti sarà inferiore alla soglia di avviso",
+      "default_disclaimer": "Disclaimer di default",
+      "privacy_disclaimer": "Disclaimer Privacy",
+      "tos_disclaimer": "Disclaimer Termini di utilizzo",
+      "default": "Default"
     },
     "hotspot": {
       "yes": "Sì",
@@ -171,7 +175,10 @@
       "create_voucher_custom": "Crea un voucher custom",
       "voucher_custom_code": "Codice",
       "i_agree": "Acconsento alle condizioni generali di utilizzo",
-      "tos_and_privacy": "ToS e Privacy"
+      "tos_and_privacy": "ToS e Privacy",
+      "privacy_disclaimer": "Disclaimer Privacy",
+      "tos_disclaimer": "Disclaimer Termini di utilizzo",
+      "disclaimer_default": "Default"
     },
     "user": {
       "username": "Utente",
@@ -248,7 +255,18 @@
       "site": "Sito",
       "enable": "Abilita",
       "disable": "Disabilita",
-      "integration": "Integrazione"
+      "integration": "Integrazione",
+      "add_disclaimer": "Aggiungi disclaimer",
+      "no_disclaimer": "Nessun disclaimer",
+      "disclaimers": "Disclaimer",
+      "disclaimer_title": "Nome",
+      "disclaimer_type": "Tipo",
+      "disclaimer_body": "Testo",
+      "privacy": "Privacy",
+      "tos": "Termini di utilizzo",
+      "add": "Aggiungi",
+      "delete_disclaimer": "Elimina disclaimer",
+      "delete_disclaimer_confirm": "Stai per eliminare il disclaimer"
     },
     "unit": {
       "unit": "Unità",
@@ -448,6 +466,8 @@
     "upload_file_not_supported": "Tipo file non supportato, utilizzare file png, jpeg o jpg",
     "upload_file_exceed": "File troppo grande (dimensione massima 700 KB)",
     "result": "Risultato",
-    "results": "Risultati"
+    "results": "Risultati",
+    "are_you_sure": "Sei sicuro",
+    "warning": "Attenzione"
   }
 }

--- a/sun/sun-ui/src/services/disclaimer.js
+++ b/sun/sun-ui/src/services/disclaimer.js
@@ -1,0 +1,46 @@
+var DisclaimerService = {
+  methods: {
+    disclaimersByAccount(accountId, success, error) {
+      this.$http
+        .get(
+          this.$root.$options.api_scheme +
+          this.$root.$options.api_host +
+          "/api/disclaimers/accounts/" + accountId, {
+            headers: {
+              Token: (this.get("loggedUser") && this.get("loggedUser").token) || ""
+            }
+          }
+        )
+        .then(success, error);
+    },
+    disclaimerCreate(body, accountId, success, error) {
+      this.$http
+        .post(
+          this.$root.$options.api_scheme +
+          this.$root.$options.api_host +
+          "/api/disclaimers/accounts/" + accountId, body, {
+            headers: {
+              Token: (this.get("loggedUser") && this.get("loggedUser").token) || ""
+            }
+          }
+        )
+        .then(success, error);
+    },
+    disclaimerDelete(disclaimerId, success, error) {
+      this.$http
+        .delete(
+          this.$root.$options.api_scheme +
+          this.$root.$options.api_host +
+          "/api/disclaimers/" +
+          disclaimerId, {
+            headers: {
+              Token:
+                (this.get("loggedUser") && this.get("loggedUser").token) || ""
+            }
+          }
+        )
+        .then(success, error);
+    },
+  }
+};
+export default DisclaimerService;

--- a/sun/sun-ui/src/services/hotspot.js
+++ b/sun/sun-ui/src/services/hotspot.js
@@ -158,6 +158,20 @@ var HotspotService = {
           uuid
         )
         .then(success, error);
+    },
+    hotspotPrivacyAll(body, success, error) {
+      this.$http
+        .get(
+          this.$root.$options.wax_url +
+          "/wax/privacy/", 
+          body, {
+            headers: {
+              Token:
+                (this.get("loggedUser") && this.get("loggedUser").token) || ""
+            }
+          }
+        )
+        .then(success, error);
     }
   }
 };

--- a/sun/sun-ui/src/services/preference.js
+++ b/sun/sun-ui/src/services/preference.js
@@ -32,7 +32,40 @@ var PreferenceService = {
           }
         )
         .then(success, error);
-    }
+    },
+    accountPrefGet(accountId, success, error) {
+      this.$http
+        .get(
+          this.$root.$options.api_scheme +
+            this.$root.$options.api_host +
+            "/api/preferences/accounts/" +
+            accountId,
+          {
+            headers: {
+              Token:
+                (this.get("loggedUser") && this.get("loggedUser").token) || ""
+            }
+          }
+        )
+        .then(success, error);
+    },
+    accountPrefModify(accountId, body, success, error) {
+      this.$http
+        .put(
+          this.$root.$options.api_scheme +
+            this.$root.$options.api_host +
+            "/api/preferences/accounts/" +
+            accountId,
+          body,
+          {
+            headers: {
+              Token:
+                (this.get("loggedUser") && this.get("loggedUser").token) || ""
+            }
+          }
+        )
+        .then(success, error);
+    },
   }
 };
 export default PreferenceService;

--- a/wax/methods/wings.go
+++ b/wax/methods/wings.go
@@ -67,12 +67,25 @@ func GetWingsPrefs(c *gin.Context) {
 	wingsPrefs.Socials.LinkedInClientId = configuration.Config.AuthSocial.LinkedIn.ClientId
 	wingsPrefs.Socials.InstagramClientId = configuration.Config.AuthSocial.Instagram.ClientId
 
-	// disclaimers
+	// default disclaimers
 	terms := configuration.Config.Disclaimers.TermsOfUse
 	marketings := configuration.Config.Disclaimers.MarketingUse
 
-	// get integration privacy text
+	var disclaimers []models.Disclaimer
 	db := database.Instance()
+
+	// custom disclaimers
+	db.Select("disclaimers.*").Where("disclaimers_hotspots.hotspot_id = ?", hotspot.Id).Joins("JOIN disclaimers_hotspots on disclaimers_hotspots.disclaimer_id = disclaimers.id").Find(&disclaimers)
+
+	for _, disclaimer := range disclaimers {
+		if disclaimer.Type == "privacy" {
+			marketings = disclaimer.Body
+		} else if disclaimer.Type == "tos" {
+			terms = disclaimer.Body
+		}
+	}
+
+	// get integration privacy text
 	db.Where("hotspot_id in (?)", hotspot.Id).Find(&hotspotIntegrations)
 
 	for _, hotspotIntegration := range hotspotIntegrations {


### PR DESCRIPTION
Different countries use different languages and privacy laws.
Custom privacy and TOS disclaimers can be associated to accounts and hotspots:
- Admins can create custom disclaimers and associate them to specific managers
- In Profile page managers can choose their default privacy and TOS disclaimers among those added by admins
- Every hotspot can be configured with specific privacy and TOS disclaimers

Related PR: https://github.com/nethesis/icaro/pull/140