### PR TITLE
wings. added origin trial token for chrome

### DIFF
--- a/wings/index.html
+++ b/wings/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta http-equiv="origin-trial" content="Aq5sIS+Eu9dLF5SxFWE72uBRvbXJBZoBRWkJBWbDzL1GsEX/oiBMJe/CebdklsUBv1wVHumaDDathJfi8PC72AcAAACGeyJvcmlnaW4iOiJodHRwOi8vbXkubmV0aHNwb3QuY29tOjgwIiwiZmVhdHVyZSI6IlByaXZhdGVOZXR3b3JrQWNjZXNzTm9uU2VjdXJlQ29udGV4dHNBbGxvd2VkIiwiZXhwaXJ5IjoxNjUyNzc0NDAwLCJpc1N1YmRvbWFpbiI6dHJ1ZX0=">
     <title>Wings</title>
     <link href="/wings/static/css/fonts.css" rel="stylesheet">
   </head>


### PR DESCRIPTION
Google Chrome starting from version 94, does not allow anymore to make request from unsecured source to local private network. This PR temporary fix the problem using the "Origin Trials" token from Chrome Developers.

Deprecation reference: https://developer.chrome.com/blog/private-network-access-update/
Solution Reference: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md