### PR TITLE
deploy: Google Chrome origin trial token

### DIFF
--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -4,6 +4,9 @@ icaro:
   version: "autobuild"
   hostname: "localhost"
   tls: "self_signed"
+  # Google Chrome trial token for allow Private Network Access from non-secure contexts
+  # see https://developer.chrome.com/blog/private-network-access-update/#register-deprecation-trial
+  #origin_trial_token: ""
   db_root_password: "YourMariaDBPassWordHere"
   sun_api_origin: "http://localhost:8080"
   wax_origin: "http://localhost:8081"

--- a/deploy/ansible/roles/icaro/templates/icaro-caddy.j2
+++ b/deploy/ansible/roles/icaro/templates/icaro-caddy.j2
@@ -31,6 +31,9 @@ http://{$ICARO_HOSTNAME}/wings {
     if {path} not_starts_with /wings/static/
     to {path} /
   }
+{% if 	icaro.origin_trial_token is defined %}
+  header / Origin-Trial "{{ icaro.origin_trial_token }}"
+{% endif %}
   log / stdout {combined}
 }
 


### PR DESCRIPTION
Due to a change in the policy of Google Chrome, is no longer possible
request an http local resource from an http page.

This change doesn't allow anymore to call the local chilli instance from
the authentication portal and the users cannot request the access to
internet even if the authentication was successful.

As a temporary workaround, a token can be requested to disabling this
feature in Google Chrome browsers.

See https://developer.chrome.com/blog/private-network-access-update/#register-deprecation-trial