### PR TITLE
added support for maxclients option

### DIFF
--- a/dedalo/README.md
+++ b/dedalo/README.md
@@ -23,7 +23,8 @@ Available options:
 - ``HS_DHCPEND``: last octet of the last ip address of dhcp range, eg: 192.168.182.55 this value should be only ``55``. (default 254)
 - ``HS_ALLOW_ORIGIN``: hosts allowed to execute CORS requests to Dedalo, usually it corresponds to ``HS_SPLASH_PAGE_URL``, eg: ``http://icaro.mydomain.com``
 - ``HS_DNS1`` and ``HS_DNS2``: primary and secondary dns servers, if not sets, will be used the default servers (OpenDNS).
-- '`USE_UPDOWN_SCRIPTS`: flag for enable/disable use of dedalo's ipup and ipdown scripts.
+- ``HS_MAXCLIENTS``: size of the DHCP IP pool (default `512`).
+- ``USE_UPDOWN_SCRIPTS``: flag for enable/disable use of dedalo's ipup and ipdown scripts.
 
 ### Example
 ```ini

--- a/dedalo/template/chilli.conf.tpl
+++ b/dedalo/template/chilli.conf.tpl
@@ -23,6 +23,7 @@ ${HS_DHCPEND:+"dhcpend  $HS_DHCPEND"}
 macauth
 
 uamdomain       "${HS_AAA_HOST}"
+${HS_MAXCLIENTS:+"maxclients       "$HS_MAXCLIENTS""}
 
 include /opt/icaro/dedalo/walled_gardens/local.conf
 include /opt/icaro/dedalo/walled_gardens/facebook.conf


### PR DESCRIPTION
now we can use maxclients option to increase the chilli's DHCP leases over the standard 512 clients.

See #158