### PR TITLE
wings. added i18n for login buttons

### DIFF
--- a/wings/src/components/LoginPage.vue
+++ b/wings/src/components/LoginPage.vue
@@ -41,7 +41,7 @@
         <div v-if="hotspot.preferences.facebook_login == 'true'" class="item">
           <div @click="changeRoute('/login/facebook', false)" class="ui facebook button big fluid" :style="buttonStyle">
             <i class="facebook icon"></i>
-            Facebook
+            {{ $t("login.with_facebook") }}
           </div>
         </div>
         <div v-if="hotspot.preferences.instagram_login == 'true'" class="item">
@@ -51,13 +51,13 @@
             :style="buttonStyle"
           >
             <i class="instagram icon"></i>
-            Instagram
+            {{ $t("login.with_instagram") }}
           </div>
         </div>
         <div v-if="hotspot.preferences.linkedin_login == 'true'" class="item">
           <div @click="changeRoute('/login/linkedin', false)" class="ui linkedin button big fluid" :style="buttonStyle">
             <i class="linkedin icon"></i>
-            LinkedIn
+            {{ $t("login.with_linkedin") }}
           </div>
         </div>
       </div>
@@ -66,13 +66,13 @@
         <div v-if="hotspot.preferences.sms_login == 'true'" class="item">
           <div @click="changeRoute('/login/sms', false)" class="ui button yellow big fluid" :style="buttonStyle">
             <i class="talk icon"></i>
-            SMS
+            {{ $t("login.with_sms") }}
           </div>
         </div>
         <div v-if="hotspot.preferences.email_login == 'true'" class="item">
           <div @click="changeRoute('/login/email', false)" class="ui button red big fluid" :style="buttonStyle">
             <i class="mail icon"></i>
-            Email
+            {{ $t("login.with_email") }}
           </div>
         </div>
       </div>
@@ -81,7 +81,7 @@
         <div v-if="hotspot.preferences.temp_code_login == 'true'" class="item">
           <div @click="changeRoute('/login', true)" class="ui button teal big fluid" :style="buttonStyle">
             <i class="barcode icon"></i>
-            {{ $t("login.code") }}
+            {{ $t("login.with_code") }}
           </div>
         </div>
       </div>

--- a/wings/src/i18n/locale-en.json
+++ b/wings/src/i18n/locale-en.json
@@ -33,7 +33,13 @@
             "reason": "Reason of the Visit",
             "business": "Business",
             "family": "Family",
-            "other": "Other"
+            "other": "Other",
+            "with_facebook": "Login with Facebook",
+            "with_instagram": "Login with Instagram",
+            "with_linkedin": "Login with LinkedIn",
+            "with_sms": "Login with SMS",
+            "with_email": "Login with Email",
+            "with_code": "Login with Voucher"
         },
         "social": {
             "auth_progress": "Authorization in progress",

--- a/wings/src/i18n/locale-it.json
+++ b/wings/src/i18n/locale-it.json
@@ -33,7 +33,13 @@
             "reason": "Motivo della visita",
             "business": "Lavoro",
             "family": "Famiglia",
-            "other": "Altro"
+            "other": "Altro",
+            "with_facebook": "Login con Facebook",
+            "with_instagram": "Login con Instagram",
+            "with_linkedin": "Login con LinkedIn",
+            "with_sms": "Login con SMS",
+            "with_email": "Login con Email",
+            "with_code": "Login con Voucher"
         },
         "social": {
             "auth_progress": "Autorizzazione in corso",

--- a/wings/src/i18n/locale-pt.json
+++ b/wings/src/i18n/locale-pt.json
@@ -33,7 +33,13 @@
             "reason": "Razão da Visita",
             "business": "Profissional",
             "family": "Familiar",
-            "other": "Outro"
+            "other": "Outro",
+            "with_facebook": "Login com Facebook",
+            "with_instagram": "Login com Instagram",
+            "with_linkedin": "Login com LinkedIn",
+            "with_sms": "Login com SMS",
+            "with_email": "Login com Email",
+            "with_code": "Login com Voucher"
         },
         "social": {
             "auth_progress": "Autenticação em curso",

--- a/wings/src/i18n/locale-ru.json
+++ b/wings/src/i18n/locale-ru.json
@@ -28,7 +28,13 @@
             "reason": "Причина визита",
             "business": "Бизнес",
             "family": "семья",
-            "other": "Другой"
+            "other": "Другой",
+            "with_facebook": "Войти через Facebook",
+            "with_instagram": "Войти через Instagram",
+            "with_linkedin": "Войти через LinkedIn",
+            "with_sms": "Войти через SMS",
+            "with_email": "Войти через Эл. адрес",
+            "with_code": "Войти через Ваучер"
         },
         "social": {
             "auth_progress": "Идёт авторизация",


### PR DESCRIPTION
To match new Facebook requirements we have to change the login buttons from "Facebook" to "Login with Facebook". To uniform the interface, we change also the other login buttons, such as Instagram or LinkedIn.