### PR TITLE
sun-tasks. remove useless data from daemon_auths table every hour

### DIFF
--- a/sun/sun-tasks/tasks/tasks.go
+++ b/sun/sun-tasks/tasks/tasks.go
@@ -62,7 +62,7 @@ func Init(action string, worker bool) {
 		storeUsers()
 
 	case "clean-auths":
-		c.AddFunc("@daily", cleanAuths)
+		c.AddFunc("@every 1h", cleanAuths)
 		cleanAuths()
 
 	default:
@@ -77,7 +77,7 @@ func Init(action string, worker bool) {
 
 func cleanAuths() {
 	db := database.Instance()
-	db.Where("updated < ? AND type = 'login'", time.Now().AddDate(0, 0, -1).UTC()).Delete(models.DaemonAuth{})
+	db.Where("updated < ?", time.Now().AddDate(0, 0, -1).UTC()).Delete(models.DaemonAuth{})
 }
 
 func cleanTokens() {


### PR DESCRIPTION
To prevent useless data inside the `daemon_auths` table, such as missing login auth flows or voucher data without username or password.