### PR TITLE
dedalo auth service: fix description

### DIFF
--- a/dedalo/dedalo_users_auth.service
+++ b/dedalo/dedalo_users_auth.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Dedalo's users authentcation daemon
+Description=Dedalo's users authentication daemon
 After=dedalo.service
 BindsTo=dedalo.service
 


### PR DESCRIPTION
Fix a small typo inside the unit description
