### PR TITLE
wax. short url: fix base64 encoding to match standard rfc

### DIFF
--- a/sun/sun-tasks/tasks/tasks.go
+++ b/sun/sun-tasks/tasks/tasks.go
@@ -77,7 +77,7 @@ func Init(action string, worker bool) {
 
 func cleanAuths() {
 	db := database.Instance()
-	db.Where("updated < ?", time.Now().AddDate(0, 0, -1).UTC()).Delete(models.DaemonAuth{})
+	db.Where("updated < ?", time.Now().Add(-1 * time.Hour).UTC()).Delete(models.DaemonAuth{})
 }
 
 func cleanTokens() {

--- a/wax/utils/utils.go
+++ b/wax/utils/utils.go
@@ -363,7 +363,7 @@ func GenerateShortURL(longURL string, uamip string, uamport string, keepURL bool
 	s := fmt.Sprintf("%.7s", fmt.Sprintf("%x", h.Sum(nil)))
 	//Encode the first 7 digits in Base64 without padding and url safe
 	encoded := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(s))
-	encodedURL := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(longURL))
+	encodedURL := base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString([]byte(longURL))
 
 	db.Where("hash = ? ", encoded).First(&shortUrl)
 


### PR DESCRIPTION
To match standard RFC base64 encoding, we change the golang function to encode base64 string