### PR TITLE
sun-api & sun-ui. added privacy fields

### DIFF
--- a/deploy/ansible/roles/icarodb/files/icaro.sql
+++ b/deploy/ansible/roles/icarodb/files/icaro.sql
@@ -8,6 +8,12 @@ CREATE TABLE `accounts` (
   `username` varchar (200) NOT NULL,
   `password` varchar (200) NOT NULL,
   `email` varchar(250),
+  `privacy_name` varchar(512),
+  `privacy_vat` varchar(512),
+  `privacy_address` varchar(512),
+  `privacy_email` varchar(512),
+  `privacy_dpo` varchar(512),
+  `privacy_dpo_mail` varchar(512),
   `created` datetime,
   UNIQUE KEY (`username`),
   UNIQUE KEY (`uuid`),
@@ -17,7 +23,7 @@ CREATE TABLE `accounts` (
 );
 
 /* CREATE DEFAULT ADMIN USER */
-INSERT INTO `accounts` VALUES (1, 0, "", "admin", "Admin", "admin", MD5("admin"), "", NOW());
+INSERT INTO `accounts` VALUES (1, 0, "", "admin", "Admin", "admin", MD5("admin"), "", "", "", "", "", "", "", NOW());
 
 CREATE TABLE `account_preferences` (
   `id` serial,

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -11,25 +11,21 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
            Riportato nel Termini di servizio
 
     Responsabile del trattamento
-       Rivenditore del servizio contrattualizzato con il Titolare del trattamento
-
-    Sub-Responsabile del trattamento
-       Nome          {{ or .PrivacyName \"Nethesis s.r.l.U.\" }}
-       Indirizzo     {{ or .PrivacyAddress \"Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA\" }}
-       P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
-       Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
-
 {{ if .PrivacyName}}
-{{ if and .PrivacyDPO .PrivacyDPOMail }}
-    DPO - Responsabile della protezione dei dati
-       Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
-       Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
-{{ end }}
+    Nome          {{ or .PrivacyName \"Nethesis s.r.l.U.\" }}
+    Indirizzo     {{ or .PrivacyAddress \"Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA\" }}
+    P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
+    Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
+
+    {{ if and .PrivacyDPO .PrivacyDPOMail }}
+        DPO - Responsabile della protezione dei dati
+        Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
+        Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
+    {{ end }}
 {{ else }}
-    DPO - Responsabile della protezione dei dati
-       Nome      Avvera s.r.l.
-       Email     avvera@legalmail.it
+       Rivenditore del servizio contrattualizzato con il Titolare del trattamento
 {{ end }}
+
     Dati trattati nell'utilizzo dell'Hotspot
        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -4,96 +4,96 @@ Ai sensi degli artt. 13 e 14 del Regolamento 2016/679/UE
 In conformità con i requisiti posti dal Regolamento Generale in materia di protezione dei dati personali il Titolare del trattamento fornisce all’interessato le seguenti informazioni in relazione ai trattamenti di dati personali effettuati.
 
 1. TRATTAMENTO HOTSPOT
-	Denominazione 	
-	   UTILIZZO DEL SERVIZIO DI RETE WIRELESS
+    Denominazione
+       UTILIZZO DEL SERVIZIO DI RETE WIRELESS
 
-	Titolare del trattamento
-           Riportato nel Termini di servizio 
+    Titolare del trattamento
+           Riportato nel Termini di servizio
 
-	Responsabile del trattamento
-	   Rivenditore del servizio contrattualizzato con il Titolare del trattamento
+    Responsabile del trattamento
+       Rivenditore del servizio contrattualizzato con il Titolare del trattamento
 
-	Sub-Responsabile del trattamento
-	   Nome 	{{ .PrivacyName }}
-	   Indirizzo 	{{ .PrivacyAddress }}
-	   P.IVA / CF 	{{ .PrivacyVAT }} 
-	   Contatto privacy 	{{ .PrivacyEmail }}
-	
-	   DPO - Responsabile della protezione dei dati
-	   Nome 	{{ .PrivacyDPO }}
-	   Email 	{{ .PrivacyDPOMail }}
+    Sub-Responsabile del trattamento
+       Nome          {{ or .PrivacyName \"Nethesis s.r.l.U.\" }}
+       Indirizzo     {{ or .PrivacyAddress \"Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA\" }}
+       P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
+       Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
 
-	Dati trattati nell'utilizzo dell'Hotspot
-	   VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+       DPO - Responsabile della protezione dei dati
+       Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
+       Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
 
-	Durata del trattamento: 
-	   VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+    Dati trattati nell'utilizzo dell'Hotspot
+       VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
-	Base giuridica: 
-   	   VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
-	
-	Natura del conferimento:
-	   VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+    Durata del trattamento:
+       VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+
+    Base giuridica:
+          VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+
+    Natura del conferimento:
+       VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
 2. TRATTAMENTO USO DEL SITO
-	Denominazione 	
-           Navigazione del sito web che ospita il servizio di autenticazione 
+    Denominazione
+        Navigazione del sito web che ospita il servizio di autenticazione
 
-	Descrizione 	
-           Si tratta dei dati raccolti automaticamente durante la navigazione esclusivamente sul sito internet del Titolare all'indirizzo my.nethspot.com e quelli comunicati spontaneamente dall'Utente tramite il modulo di contatto.
+    Descrizione
+        Si tratta dei dati raccolti automaticamente durante la navigazione esclusivamente sul sito internet del Titolare all'indirizzo my.nethspot.com e quelli comunicati spontaneamente dall'Utente tramite il modulo di contatto.
 
-	Data ultima revisione
-    	   15/02/2024
+    Data ultima revisione
+        15/02/2024
 
-	Titolare del trattamento
-	   Nome 	{{ .PrivacyName }}
-	   Indirizzo 	{{ .PrivacyAddress }}
-	   P.IVA / CF 	{{ .PrivacyVAT }}
-	   Contatto privacy 	{{ .PrivacyEmail }}
-	
-	   DPO - Responsabile della protezione dei dati
-	   Nome 	{{ .PrivacyDPO }}
-	   Email 	{{ .PrivacyDPOMail }}
+    Titolare del trattamento
+        Nome          {{ or .PrivacyName \"Nethesis s.r.l.U.\" }}
+        Indirizzo     {{ or .PrivacyAddress \"Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA\" }}
+        P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
+        Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
 
-	Dati trattati nella navigazione del sito
-	   Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)
-	   Dati particolari trattati : nessuno
+        DPO - Responsabile della protezione dei dati
+        Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
+        Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
 
-	Durata del trattamento: 
-	   conservazione dei log per 180 giorni. 
+    Dati trattati nella navigazione del sito
+       Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)
+       Dati particolari trattati : nessuno
 
-	Base giuridica: 
-	   legittimo interesse (art. 6, par. 1 lett. f) e considerando 47 GDPR): il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell’interessato che richiedono la protezione dei dati personali, tenuto conto delle ragionevoli aspettative nutrite dall’interessato in base alla sua relazione con il titolare del trattamento. Attività strettamente necessarie al funzionamento del sito e all’erogazione del servizio di navigazione sulla piattaforma. 
-	
-	Natura del conferimento:
-	   necessaria al fine di permettere la navigazione del sito web.Il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi
+    Durata del trattamento:
+       conservazione dei log per 180 giorni.
+
+    Base giuridica:
+       legittimo interesse (art. 6, par. 1 lett. f) e considerando 47 GDPR): il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell’interessato che richiedono la protezione dei dati personali, tenuto conto delle ragionevoli aspettative nutrite dall’interessato in base alla sua relazione con il titolare del trattamento. Attività strettamente necessarie al funzionamento del sito e all’erogazione del servizio di navigazione sulla piattaforma.
+
+    Natura del conferimento:
+       necessaria al fine di permettere la navigazione del sito web.Il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi
 
 Se intende richiedere ulteriori informazioni sul trattamento dei Suoi dati personali o per l'eventuale esercizio dei Suoi diritti, potrà rivolgersi per iscritto direttamente al contatto privacy sopra indicato.
 
 In conformità con i requisiti posti dal Regolamento Generale in materia di protezione dei dati personali il Titolare del trattamento fornisce all’interessato le seguenti informazioni in relazione ai trattamenti di dati personali effettuati.
- 	
+
 DIRITTI DEGLI INTERESSATI - Artt. da 15 a 22 e dall'art. 13 del GDPR.
 
 Diritto di accesso
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare l'accesso ai propri dati personali.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare l'accesso ai propri dati personali.
 
 Diritto di rettifica.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare la rettifica dei propri dati personali.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare la rettifica dei propri dati personali.
 
 Diritto di cancellazione.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare la cancellazione dei propri dati personali.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare la cancellazione dei propri dati personali.
 
 Diritto di limitazione.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare la limitazione dei dati che lo riguardano.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di richiedere al titolare la limitazione dei dati che lo riguardano.
 
 Diritto di opposizione.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di opporsi al loro trattamento.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di opporsi al loro trattamento.
 
 Diritto di portabilità.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di esercitare il proprio diritto alla portabilità dei dati.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di esercitare il proprio diritto alla portabilità dei dati.
 
 Diritto di revoca.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di esercitare il proprio diritto alla revoca del consenso.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di esercitare il proprio diritto alla revoca del consenso.
 
 Diritto di reclamo.
-	L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di esercitare il proprio diritto di porre reclamo dinanzi all'autorità di controllo.
+    L'interessato ha diritto, secondo quanto previsto dagli artt. da 15 a 22 e dall' art. 13 del GDPR di esercitare il proprio diritto di porre reclamo dinanzi all'autorità di controllo.

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -44,7 +44,8 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
         Si tratta dei dati raccolti automaticamente durante la navigazione esclusivamente sul sito internet del Titolare all'indirizzo my.nethspot.com e quelli comunicati spontaneamente dall'Utente tramite il modulo di contatto.
 
     Data ultima revisione
-        15/02/2024
+        14/06/2024
+
 
     Titolare del trattamento
         Nome                    Nethesis s.r.l.U.

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -12,15 +12,15 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
 
     Responsabile del trattamento
 {{ if .PrivacyName}}
-    Nome          {{ or .PrivacyName \"Nethesis s.r.l.U.\" }}
-    Indirizzo     {{ or .PrivacyAddress \"Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA\" }}
-    P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
-    Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
+    Nome          {{ .PrivacyName }}
+    Indirizzo     {{ .PrivacyAddress }}
+    P.IVA / CF    {{ .PrivacyVAT }}
+    Contatto privacy     {{ .PrivacyEmail }}
 
     {{ if and .PrivacyDPO .PrivacyDPOMail }}
         DPO - Responsabile della protezione dei dati
-        Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
-        Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
+        Nome      {{ .PrivacyDPO }}
+        Email     {{ .PrivacyDPOMail }}
     {{ end }}
 {{ else }}
        Rivenditore del servizio contrattualizzato con il Titolare del trattamento

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -47,17 +47,17 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
         15/02/2024
 
     Titolare del trattamento
-        Nome 	                Nethesis s.r.l.U.
-        Indirizzo 	            Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA
-        P.IVA / CF 	            02734760412 / 02734760412
-        Legale rappresentante 	CRISTIAN MANONI
-        Contatto privacy 	    privacy@nethesis.it
-        PEC 	                nethesis@pec.it
-        Telefono 	            07211791157
+        Nome                    Nethesis s.r.l.U.
+        Indirizzo               Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA
+        P.IVA / CF              02734760412 / 02734760412
+        Legale rappresentante   CRISTIAN MANONI
+        Contatto privacy        privacy@nethesis.it
+        PEC                     nethesis@pec.it
+        Telefono                07211791157
 
     DPO - Responsabile della protezione dei dati
-        Nome 	    Avvera s.r.l.
-        Indirizzo 	Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
+        Nome         Avvera s.r.l.
+        Indirizzo    Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
 
     Dati trattati nella navigazione del sito
        Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -5,38 +5,38 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
 
 1. TRATTAMENTO HOTSPOT
     Denominazione
-       UTILIZZO DEL SERVIZIO DI RETE WIRELESS
+        UTILIZZO DEL SERVIZIO DI RETE WIRELESS
 
     Titolare del trattamento
-           Riportato nel Termini di servizio
+        Riportato nel Termini di servizio
 
     Responsabile del trattamento
 {{ if .PrivacyName}}
-    Ragione Sociale      {{ .PrivacyName }}
-    Indirizzo            {{ .PrivacyAddress }}
-    P.IVA / CF           {{ .PrivacyVAT }}
-    Contatto privacy     {{ .PrivacyEmail }}
+        Ragione Sociale      {{ .PrivacyName }}
+        Indirizzo            {{ .PrivacyAddress }}
+        P.IVA / CF           {{ .PrivacyVAT }}
+        Contatto privacy     {{ .PrivacyEmail }}
 
     {{ if and .PrivacyDPO .PrivacyDPOMail }}
         DPO - Responsabile della protezione dei dati
-        Nome DPO      {{ .PrivacyDPO }}
-        Email DPO     {{ .PrivacyDPOMail }}
+            Nome DPO         {{ .PrivacyDPO }}
+            Email DPO        {{ .PrivacyDPOMail }}
     {{ end }}
 {{ else }}
-       Rivenditore del servizio contrattualizzato con il Titolare del trattamento
+        Rivenditore del servizio contrattualizzato con il Titolare del trattamento
 {{ end }}
 
     Dati trattati nell'utilizzo dell'Hotspot
-       VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
     Durata del trattamento:
-       VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
     Base giuridica:
-          VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
     Natura del conferimento:
-       VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
+        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
 2. TRATTAMENTO USO DEL SITO
     Denominazione
@@ -63,17 +63,17 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
         Indirizzo    Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
 
     Dati trattati nella navigazione del sito
-       Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)
-       Dati particolari trattati : nessuno
+        Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)
+        Dati particolari trattati : nessuno
 
     Durata del trattamento:
-       conservazione dei log per 180 giorni.
+        conservazione dei log per 180 giorni.
 
     Base giuridica:
-       legittimo interesse (art. 6, par. 1 lett. f) e considerando 47 GDPR): il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell’interessato che richiedono la protezione dei dati personali, tenuto conto delle ragionevoli aspettative nutrite dall’interessato in base alla sua relazione con il titolare del trattamento. Attività strettamente necessarie al funzionamento del sito e all’erogazione del servizio di navigazione sulla piattaforma.
+        legittimo interesse (art. 6, par. 1 lett. f) e considerando 47 GDPR): il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi, a condizione che non prevalgano gli interessi o i diritti e le libertà fondamentali dell’interessato che richiedono la protezione dei dati personali, tenuto conto delle ragionevoli aspettative nutrite dall’interessato in base alla sua relazione con il titolare del trattamento. Attività strettamente necessarie al funzionamento del sito e all’erogazione del servizio di navigazione sulla piattaforma.
 
     Natura del conferimento:
-       necessaria al fine di permettere la navigazione del sito web.Il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi
+        necessaria al fine di permettere la navigazione del sito web.Il trattamento è necessario per il perseguimento del legittimo interesse del titolare del trattamento o di terzi
 
 Se intende richiedere ulteriori informazioni sul trattamento dei Suoi dati personali o per l'eventuale esercizio dei Suoi diritti, potrà rivolgersi per iscritto direttamente al contatto privacy sopra indicato.
 

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -19,11 +19,17 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
        P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
        Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
 
+{{ if .PrivacyName}}
 {{ if and .PrivacyDPO .PrivacyDPOMail }}
     DPO - Responsabile della protezione dei dati
        Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
        Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
-{{end}}
+{{ end }}
+{{ else }}
+    DPO - Responsabile della protezione dei dati
+       Nome      Avvera s.r.l.
+       Email     avvera@legalmail.it
+{{ end }}
     Dati trattati nell'utilizzo dell'Hotspot
        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -12,15 +12,15 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
 
     Responsabile del trattamento
 {{ if .PrivacyName}}
-    Nome          {{ .PrivacyName }}
-    Indirizzo     {{ .PrivacyAddress }}
-    P.IVA / CF    {{ .PrivacyVAT }}
+    Ragione Sociale      {{ .PrivacyName }}
+    Indirizzo            {{ .PrivacyAddress }}
+    P.IVA / CF           {{ .PrivacyVAT }}
     Contatto privacy     {{ .PrivacyEmail }}
 
     {{ if and .PrivacyDPO .PrivacyDPOMail }}
         DPO - Responsabile della protezione dei dati
-        Nome      {{ .PrivacyDPO }}
-        Email     {{ .PrivacyDPOMail }}
+        Nome DPO      {{ .PrivacyDPO }}
+        Email DPO     {{ .PrivacyDPOMail }}
     {{ end }}
 {{ else }}
        Rivenditore del servizio contrattualizzato con il Titolare del trattamento

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -16,7 +16,6 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
         Indirizzo            {{ .PrivacyAddress }}
         P.IVA / CF           {{ .PrivacyVAT }}
         Contatto privacy     {{ .PrivacyEmail }}
-
     {{ if and .PrivacyDPO .PrivacyDPOMail }}
         DPO - Responsabile della protezione dei dati
             Nome DPO         {{ .PrivacyDPO }}
@@ -25,7 +24,6 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
 {{ else }}
         Rivenditore del servizio contrattualizzato con il Titolare del trattamento
 {{ end }}
-
     Dati trattati nell'utilizzo dell'Hotspot
         VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -46,14 +46,17 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
         15/02/2024
 
     Titolare del trattamento
-        Nome          {{ or .PrivacyName \"Nethesis s.r.l.U.\" }}
-        Indirizzo     {{ or .PrivacyAddress \"Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA\" }}
-        P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
-        Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
+        Nome 	                Nethesis s.r.l.U.
+        Indirizzo 	            Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA
+        P.IVA / CF 	            02734760412 / 02734760412
+        Legale rappresentante 	CRISTIAN MANONI
+        Contatto privacy 	    privacy@nethesis.it
+        PEC 	                nethesis@pec.it
+        Telefono 	            07211791157
 
         DPO - Responsabile della protezione dei dati
-        Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
-        Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
+        Nome 	    Avvera s.r.l.
+        Indirizzo 	Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
 
     Dati trattati nella navigazione del sito
        Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -14,17 +14,14 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
 	   Rivenditore del servizio contrattualizzato con il Titolare del trattamento
 
 	Sub-Responsabile del trattamento
-	   Nome 	Nethesis s.r.l.U.
-	   Indirizzo 	Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA
-	   P.IVA / CF 	02734760412 / 02734760412 
-	   Legale rappresentante 	CRISTIAN MANONI
-	   Contatto privacy 	privacy@nethesis.it
-	   PEC 	nethesis@pec.it
-	   Telefono 	07211791157
+	   Nome 	{{ .PrivacyName }}
+	   Indirizzo 	{{ .PrivacyAddress }}
+	   P.IVA / CF 	{{ .PrivacyVAT }} 
+	   Contatto privacy 	{{ .PrivacyEmail }}
 	
 	   DPO - Responsabile della protezione dei dati
-	   Nome 	Avvera s.r.l.
-	   Indirizzo 	Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
+	   Nome 	{{ .PrivacyDPO }}
+	   Email 	{{ .PrivacyDPOMail }}
 
 	Dati trattati nell'utilizzo dell'Hotspot
 	   VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
@@ -49,17 +46,14 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
     	   15/02/2024
 
 	Titolare del trattamento
-	   Nome 	Nethesis s.r.l.U.
-	   Indirizzo 	Via degli Olmi 8, 61122 Pesaro (PU) - ITALIA
-	   P.IVA / CF 	02734760412 / 02734760412 
-	   Legale rappresentante 	CRISTIAN MANONI
-	   Contatto privacy 	privacy@nethesis.it
-	   PEC 	nethesis@pec.it
-	   Telefono 	07211791157
+	   Nome 	{{ .PrivacyName }}
+	   Indirizzo 	{{ .PrivacyAddress }}
+	   P.IVA / CF 	{{ .PrivacyVAT }}
+	   Contatto privacy 	{{ .PrivacyEmail }}
 	
 	   DPO - Responsabile della protezione dei dati
-	   Nome 	Avvera s.r.l.
-	   Indirizzo 	Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
+	   Nome 	{{ .PrivacyDPO }}
+	   Email 	{{ .PrivacyDPOMail }}
 
 	Dati trattati nella navigazione del sito
 	   Dati di navigazione (quali: indirizzo IP, indirizzi URI/URL, orario di accesso ecc.)

--- a/deploy/ansible/roles/wax/files/marketing
+++ b/deploy/ansible/roles/wax/files/marketing
@@ -19,10 +19,11 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
        P.IVA / CF    {{ or .PrivacyVAT \"02734760412 / 02734760412\" }}
        Contatto privacy     {{ or .PrivacyEmail \"privacy@nethesis.it\" }}
 
-       DPO - Responsabile della protezione dei dati
+{{ if and .PrivacyDPO .PrivacyDPOMail }}
+    DPO - Responsabile della protezione dei dati
        Nome      {{ or .PrivacyDPO \"Avvera s.r.l.\" }}
        Email     {{ or .PrivacyDPOMail \"avvera@legalmail.it\" }}
-
+{{end}}
     Dati trattati nell'utilizzo dell'Hotspot
        VEDERE LE INTEGRAZIONI SUL DOCUMENTO "Terms of use"
 
@@ -54,7 +55,7 @@ In conformità con i requisiti posti dal Regolamento Generale in materia di prot
         PEC 	                nethesis@pec.it
         Telefono 	            07211791157
 
-        DPO - Responsabile della protezione dei dati
+    DPO - Responsabile della protezione dei dati
         Nome 	    Avvera s.r.l.
         Indirizzo 	Largo Umberto Boccioni, 1 – 21040 Origgio (VA) -
 

--- a/sun/sun-api/methods/accounts.go
+++ b/sun/sun-api/methods/accounts.go
@@ -73,14 +73,20 @@ func CreateAccount(c *gin.Context) {
 	passwordHash := fmt.Sprintf("%x", h.Sum(nil))
 
 	account := models.Account{
-		CreatorId: creatorId,
-		Uuid:      json.Uuid,
-		Type:      json.Type,
-		Name:      json.Name,
-		Username:  json.Username,
-		Password:  passwordHash,
-		Email:     json.Email,
-		Created:   time.Now().UTC(),
+		CreatorId:      creatorId,
+		Uuid:           json.Uuid,
+		Type:           json.Type,
+		Name:           json.Name,
+		Username:       json.Username,
+		Password:       passwordHash,
+		Email:          json.Email,
+		PrivacyName:    "",
+		PrivacyVAT:     "",
+		PrivacyAddress: "",
+		PrivacyEmail:   "",
+		PrivacyDPO:     "",
+		PrivacyDPOMail: "",
+		Created:        time.Now().UTC(),
 	}
 
 	// create account record
@@ -181,6 +187,22 @@ func UpdateAccount(c *gin.Context) {
 	if len(json.Type) > 0 {
 		account.Type = json.Type
 	}
+
+	// privacy update
+	if len(json.PrivacyName) > 0 {
+		account.PrivacyName = json.PrivacyName
+	}
+	if len(json.PrivacyVAT) > 0 {
+		account.PrivacyVAT = json.PrivacyVAT
+	}
+	if len(json.PrivacyAddress) > 0 {
+		account.PrivacyAddress = json.PrivacyAddress
+	}
+	if len(json.PrivacyEmail) > 0 {
+		account.PrivacyEmail = json.PrivacyEmail
+	}
+	account.PrivacyDPO = json.PrivacyDPO
+	account.PrivacyDPOMail = json.PrivacyDPOMail
 
 	// NOTE: Subscription plan change is not supported
 

--- a/sun/sun-api/models/account.go
+++ b/sun/sun-api/models/account.go
@@ -25,15 +25,21 @@ package models
 import "time"
 
 type Account struct {
-	Id        int       `db:"id" json:"id"`
-	CreatorId int       `db:"creator_id" json:"creator_id"`
-	Uuid      string    `db:"uuid" json:"uuid"`
-	Type      string    `db:"type" json:"type"`
-	Name      string    `db:"name" json:"name"`
-	Username  string    `db:"username" json:"username"`
-	Password  string    `db:"password" json:"-"`
-	Email     string    `db:"email" json:"email"`
-	Created   time.Time `db:"created" json:"created"`
+	Id             int       `db:"id" json:"id"`
+	CreatorId      int       `db:"creator_id" json:"creator_id"`
+	Uuid           string    `db:"uuid" json:"uuid"`
+	Type           string    `db:"type" json:"type"`
+	Name           string    `db:"name" json:"name"`
+	Username       string    `db:"username" json:"username"`
+	Password       string    `db:"password" json:"-"`
+	Email          string    `db:"email" json:"email"`
+	PrivacyName    string    `db:"privacy_name" json:"privacy_name"`
+	PrivacyVAT     string    `db:"privacy_vat" json:"privacy_vat"`
+	PrivacyAddress string    `db:"privacy_address" json:"privacy_address"`
+	PrivacyEmail   string    `db:"privacy_email" json:"privacy_email"`
+	PrivacyDPO     string    `db:"privacy_dpo" json:"privacy_dpo"`
+	PrivacyDPOMail string    `db:"privacy_dpo_mail" json:"privacy_dpo_mail"`
+	Created        time.Time `db:"created" json:"created"`
 }
 
 type AccountJSON struct {
@@ -45,6 +51,12 @@ type AccountJSON struct {
 	Username             string        `json:"username"`
 	Password             string        `json:"password"`
 	Email                string        `json:"email"`
+	PrivacyName          string        `json:"privacy_name"`
+	PrivacyVAT           string        `json:"privacy_vat"`
+	PrivacyAddress       string        `json:"privacy_address"`
+	PrivacyEmail         string        `json:"privacy_email"`
+	PrivacyDPO           string        `json:"privacy_dpo"`
+	PrivacyDPOMail       string        `json:"privacy_dpo_mail"`
 	Created              time.Time     `json:"created"`
 	HotspotId            int           `json:"hotspot_id"`
 	HotspotName          string        `json:"hotspot_name"`

--- a/sun/sun-ui/src/components/Hotspots.vue
+++ b/sun/sun-ui/src/components/Hotspots.vue
@@ -4,7 +4,7 @@
     <div v-if="isLoading" class="spinner spinner-lg"></div>
     <div v-if="rows.length > 0 && !privacyFilled()" class="alert alert-warning alert-dismissable create-hotspot-warning">
       <span class="pficon pficon-warning-triangle-o"></span>
-      <strong>{{ $t('hotspot.warning_privacy') }}!</strong> {{ $t('hotspot.warning_privacy_text') }}: <a href="#/profile" class="alert-link">{{ $t('hotspot.profile_link') }}</a>
+      <strong>{{ $t('hotspot.warning_privacy') }}!</strong> {{ $t('hotspot.warning_privacy_text') }} <a href="#/profile" class="alert-link">{{ $t('hotspot.profile_link') }}</a>
     </div>
     <button
       v-if="rows.length > 0 && !isLoading && !isAdmin"
@@ -30,7 +30,7 @@
       <br/>
       <div v-if="!privacyFilled()" class="alert alert-warning alert-dismissable">
         <span class="pficon pficon-warning-triangle-o"></span>
-        <strong>{{ $t('hotspot.warning_privacy') }}!</strong> {{ $t('hotspot.warning_privacy_text') }}: <a href="#/profile" class="alert-link">{{ $t('hotspot.profile_link') }}</a>
+        <strong>{{ $t('hotspot.warning_privacy') }}!</strong> {{ $t('hotspot.warning_privacy_text') }} <a href="#/profile" class="alert-link">{{ $t('hotspot.profile_link') }}</a>
       </div>
     </div>
     <div

--- a/sun/sun-ui/src/components/Hotspots.vue
+++ b/sun/sun-ui/src/components/Hotspots.vue
@@ -2,11 +2,16 @@
   <div>
     <h2>{{ msg }}</h2>
     <div v-if="isLoading" class="spinner spinner-lg"></div>
+    <div v-if="rows.length > 0 && !privacyFilled()" class="alert alert-warning alert-dismissable create-hotspot-warning">
+      <span class="pficon pficon-warning-triangle-o"></span>
+      <strong>{{ $t('hotspot.warning_privacy') }}!</strong> {{ $t('hotspot.warning_privacy_text') }}: <a href="#/profile" class="alert-link">{{ $t('hotspot.profile_link') }}</a>
+    </div>
     <button
       v-if="rows.length > 0 && !isLoading && !isAdmin"
       data-toggle="modal"
       data-target="#HScreateModal"
       class="btn btn-primary btn-lg create-hotspot"
+      :disabled="!privacyFilled()"
     >{{ $t('hotspot.create_new') }}</button>
     <div v-if="rows.length == 0 && !isLoading && !isAdmin" class="blank-slate-pf" id>
       <div class="blank-slate-pf-icon">
@@ -19,7 +24,13 @@
           data-toggle="modal"
           data-target="#HScreateModal"
           class="btn btn-primary btn-lg"
+          :disabled="!privacyFilled()"
         >{{ $t('hotspot.create_new') }}</button>
+      </div>
+      <br/>
+      <div v-if="!privacyFilled()" class="alert alert-warning alert-dismissable">
+        <span class="pficon pficon-warning-triangle-o"></span>
+        <strong>{{ $t('hotspot.warning_privacy') }}!</strong> {{ $t('hotspot.warning_privacy_text') }}: <a href="#/profile" class="alert-link">{{ $t('hotspot.profile_link') }}</a>
       </div>
     </div>
     <div
@@ -410,7 +421,7 @@ export default {
         selectedTosDisclaimerId: "",
         privacyDisclaimers: [],
         tosDisclaimers: [],
-      },
+      }
     };
   },
   mounted() {
@@ -419,6 +430,14 @@ export default {
     this.getDisclaimers();
   },
   methods: {
+    privacyFilled() {
+      return (
+        this.user.info.privacy_name.length > 0 &&
+        this.user.info.privacy_vat.length > 0 &&
+        this.user.info.privacy_address.length > 0 &&
+        this.user.info.privacy_email.length > 0
+      )
+    },
     handlePerPage(evt) {
       this.set("hotspots_per_page", evt.currentPerPage);
     },

--- a/sun/sun-ui/src/components/Profile.vue
+++ b/sun/sun-ui/src/components/Profile.vue
@@ -52,6 +52,10 @@
             </h2>
           </div>
           <form v-if="!privacy.isLoading" class="form-horizontal" role="form" v-on:submit.prevent="updatePrivacyFields()">
+            <div class="alert alert-info alert-dismissable">
+              <span class="pficon pficon-info"></span>
+              <strong>{{ $t('profile.info')}}.</strong> {{ $t('profile.privacy_info') }}.
+            </div>
             <div class="card-pf-body">
                 <div class="form-group">
                   <label class="col-sm-4 control-label">{{ $t("profile.privacy_name") }}</label>

--- a/sun/sun-ui/src/components/Profile.vue
+++ b/sun/sun-ui/src/components/Profile.vue
@@ -40,6 +40,69 @@
           </div>
         </div>
       </div>
+
+      <!-- privacy fields -->
+      <div v-if="user.info.type == 'reseller'" class="col-xs-12 col-sm-12 col-md-6">
+        <div class="card-pf card-pf-accented">
+          <div class="card-pf-heading">
+            <h2 class="card-pf-title">
+              {{ $t("profile.privacy_fields") }}
+              <div v-if="!privacy.isLoading" class="fa fa-lock card-info-title right"></div>
+              <div v-if="privacy.isLoading" class="spinner spinner-sm right"></div>
+            </h2>
+          </div>
+          <form v-if="!privacy.isLoading" class="form-horizontal" role="form" v-on:submit.prevent="updatePrivacyFields()">
+            <div class="card-pf-body">
+                <div class="form-group">
+                  <label class="col-sm-4 control-label">{{ $t("profile.privacy_name") }}</label>
+                  <div class="col-sm-8">
+                    <input v-model="user.info.privacy_name" required type="text" class="form-control">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-sm-4 control-label">{{ $t("profile.privacy_vat") }}</label>
+                  <div class="col-sm-8">
+                    <input v-model="user.info.privacy_vat" required type="number" class="form-control">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-sm-4 control-label">{{ $t("profile.privacy_address") }}</label>
+                  <div class="col-sm-8">
+                    <input v-model="user.info.privacy_address" required type="text" class="form-control">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-sm-4 control-label">{{ $t("profile.privacy_email") }}</label>
+                  <div class="col-sm-8">
+                    <input v-model="user.info.privacy_email" required type="email" class="form-control">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-sm-4 control-label">{{ $t("profile.privacy_dpo") }}</label>
+                  <div class="col-sm-8">
+                    <input v-model="user.info.privacy_dpo" type="text" class="form-control">
+                  </div>
+                </div>
+                <div class="form-group">
+                  <label class="col-sm-4 control-label">{{ $t("profile.privacy_dpo_mail") }}</label>
+                  <div class="col-sm-8">
+                    <input v-model="user.info.privacy_dpo_mail" type="email" class="form-control">
+                  </div>
+                </div>
+            </div>
+            <div class="card-pf-footer">
+              <div class="dropdown card-pf-time-frame-filter">
+                <button type="submit" class="btn btn-default">{{ $t("update") }}</button>
+              </div>
+              <p>
+                <a href="#" class="card-pf-link-with-icon">
+                </a>
+              </p>
+            </div>
+          </form>
+        </div>
+      </div>
+
       <!-- SMS warning threshold -->
       <div class="col-xs-12 col-sm-12 col-md-6">
         <div class="card-pf card-pf-accented">
@@ -72,6 +135,7 @@
           </div>
         </div>
       </div>
+
       <!-- disclaimer -->
       <div
         v-if="disclaimers.data && disclaimers.data.length"
@@ -179,10 +243,11 @@ import UtilService from "../services/util";
 import StatsService from "../services/stats";
 import DisclaimerService from "../services/disclaimer";
 import PreferenceService from "../services/preference";
+import AccountService from '../services/account';
 
 export default {
   name: "Profile",
-  mixins: [LoginService, StorageService, UtilService, StatsService, DisclaimerService, PreferenceService],
+  mixins: [LoginService, StorageService, UtilService, StatsService, DisclaimerService, PreferenceService, AccountService],
   data() {
     return {
       msg: this.$i18n.t("menu.profile"),
@@ -199,6 +264,9 @@ export default {
       sms: {
         isLoading: true,
         data: {}
+      },
+      privacy: {
+        isLoading: false,
       },
       disclaimers: {
         data: {},
@@ -337,6 +405,24 @@ export default {
           }, 2000);
         }
       );
+    },
+    updatePrivacyFields() {
+      this.privacy.isLoading = true;
+      this.accountModify(this.user.login.id, {
+        privacy_name: this.user.info.privacy_name,
+        privacy_vat:  this.user.info.privacy_vat,
+        privacy_address:  this.user.info.privacy_address,
+        privacy_email:  this.user.info.privacy_email,
+        privacy_dpo:  this.user.info.privacy_dpo,
+        privacy_dpo_mail:  this.user.info.privacy_dpo_mail,
+      },
+      success => {
+        this.privacy.isLoading = false;
+      },
+      error => {
+        this.privacy.isLoading = false;
+        console.error(error.body.message);
+      });
     }
   }
 };

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -40,7 +40,14 @@
       "default_disclaimer": "Default disclaimers",
       "privacy_disclaimer": "Privacy disclaimer",
       "tos_disclaimer": "Terms of use disclaimer",
-      "default": "Default"
+      "default": "Default",
+      "privacy_fields": "Privacy fields",
+      "privacy_name": "Reseller's business name",
+      "privacy_vat": "Reseller's business VAT",
+      "privacy_address": "Reseller's business address",
+      "privacy_email": "Reseller's business email",
+      "privacy_dpo": "Reseller's business DPO (optional)",
+      "privacy_dpo_mail": "Reseller's business DPO email (optional)"
     },
     "hotspot": {
       "yes": "Yes",

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -47,7 +47,8 @@
       "privacy_address": "Reseller's business address",
       "privacy_email": "Reseller's privacy email",
       "privacy_dpo": "Reseller's business DPO (optional)",
-      "privacy_dpo_mail": "Reseller's business DPO email (optional)"
+      "privacy_dpo_mail": "Reseller's business DPO email (optional)",
+      "privacy_info": "Privacy info here"
     },
     "hotspot": {
       "yes": "Yes",

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -45,7 +45,7 @@
       "privacy_name": "Reseller's business name",
       "privacy_vat": "Reseller's business VAT",
       "privacy_address": "Reseller's business address",
-      "privacy_email": "Reseller's business email",
+      "privacy_email": "Reseller's privacy email",
       "privacy_dpo": "Reseller's business DPO (optional)",
       "privacy_dpo_mail": "Reseller's business DPO email (optional)"
     },

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -48,7 +48,7 @@
       "privacy_email": "Reseller's privacy email",
       "privacy_dpo": "Reseller's business DPO (optional)",
       "privacy_dpo_mail": "Reseller's business DPO email (optional)",
-      "privacy_info": "Privacy info here"
+      "privacy_info": "The reseller data entered in this section will be used to complete the privacy notice displayed to service users, identifying the reseller as the data controller in compliance with the GDPR."
     },
     "hotspot": {
       "yes": "Yes",

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -197,7 +197,7 @@
       "wifi4eu_zdebug": "WiFi4EU Self-test",
       "wifi4eu_zdebug_desc": "The self-test mode interrupts the correct functioning of the hotspot and should only be used for specific tests. This option should always be disabled under normal conditions.",
       "warning_privacy": "Warning",
-      "warning_privacy_text": "Warning text",
+      "warning_privacy_text": "It is necessary to fill in the reseller data before proceeding.",
       "profile_link": "Profile link"
     },
     "user": {

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -195,7 +195,10 @@
       "wifi4eu_id": "WiFi4EU Network Identifier",
       "wifi4eu_lang": "WiFi4EU Language",
       "wifi4eu_zdebug": "WiFi4EU Self-test",
-      "wifi4eu_zdebug_desc": "The self-test mode interrupts the correct functioning of the hotspot and should only be used for specific tests. This option should always be disabled under normal conditions."
+      "wifi4eu_zdebug_desc": "The self-test mode interrupts the correct functioning of the hotspot and should only be used for specific tests. This option should always be disabled under normal conditions.",
+      "warning_privacy": "Warning",
+      "warning_privacy_text": "Warning text",
+      "profile_link": "Profile link"
     },
     "user": {
       "username": "Username",

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -198,7 +198,7 @@
       "wifi4eu_zdebug_desc": "The self-test mode interrupts the correct functioning of the hotspot and should only be used for specific tests. This option should always be disabled under normal conditions.",
       "warning_privacy": "Warning",
       "warning_privacy_text": "It is necessary to fill in the reseller data before proceeding.",
-      "profile_link": "Profile link"
+      "profile_link": "Link to reseller profile"
     },
     "user": {
       "username": "Username",

--- a/sun/sun-ui/src/i18n/locale-en.json
+++ b/sun/sun-ui/src/i18n/locale-en.json
@@ -48,7 +48,7 @@
       "privacy_email": "Reseller's privacy email",
       "privacy_dpo": "Reseller's business DPO (optional)",
       "privacy_dpo_mail": "Reseller's business DPO email (optional)",
-      "privacy_info": "The reseller data entered in this section will be used to complete the privacy notice displayed to service users, identifying the reseller as the data controller in compliance with the GDPR."
+      "privacy_info": "The reseller data entered in this section will be used to complete the privacy notice displayed to service users, identifying the reseller as the data controller in compliance with the GDPR"
     },
     "hotspot": {
       "yes": "Yes",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -41,13 +41,13 @@
       "privacy_disclaimer": "Disclaimer Privacy",
       "tos_disclaimer": "Disclaimer Termini di utilizzo",
       "default": "Default",
-      "privacy_fields": "Privacy fields",
-      "privacy_name": "Reseller's business name",
-      "privacy_vat": "Reseller's business VAT",
-      "privacy_address": "Reseller's business address",
-      "privacy_email": "Reseller's business email",
-      "privacy_dpo": "Reseller's business DPO (optional)",
-      "privacy_dpo_mail": "Reseller's business DPO email (optional)"
+      "privacy_fields": "Dati privacy Reseller",
+      "privacy_name": "Ragione Sociale",
+      "privacy_vat": "Partita IVA/CF",
+      "privacy_address": "Indirizzo",
+      "privacy_email": "Email per comunicazioni privacy",
+      "privacy_dpo": "NOme del DPO (opzionale)",
+      "privacy_dpo_mail": "Email del DPO (opzionale)"
     },
     "hotspot": {
       "yes": "Sì",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -188,7 +188,10 @@
       "wifi4eu_id": "WiFi4EU Identificatore Rete",
       "wifi4eu_lang": "WiFi4EU Lingua",
       "wifi4eu_zdebug": "WiFi4EU Autotest",
-      "wifi4eu_zdebug_desc": "La modalità autotest interrompe il corretto funzionamento dell'hotspot e va utilizzata solo per specifiche verifiche. Questa opzione in condizioni normali deve essere sempre disabilitata."
+      "wifi4eu_zdebug_desc": "La modalità autotest interrompe il corretto funzionamento dell'hotspot e va utilizzata solo per specifiche verifiche. Questa opzione in condizioni normali deve essere sempre disabilitata.",
+      "warning_privacy": "Attenzione",
+      "warning_privacy_text": "Attenzione text",
+      "profile_link": "Profilo link"
     },
     "user": {
       "username": "Utente",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -48,7 +48,7 @@
       "privacy_email": "Email per comunicazioni privacy",
       "privacy_dpo": "Nome del DPO (opzionale)",
       "privacy_dpo_mail": "Email del DPO (opzionale)",
-      "privacy_info": "I dati del rivenditore inseriti in questa sezione saranno usati per compilare l'informativa privacy visualizzata agli utilizzatori del servizio qualificandolo come responsabile del trattamento in ottemperanza al GDPR."
+      "privacy_info": "I dati del rivenditore inseriti in questa sezione saranno usati per compilare l'informativa privacy visualizzata agli utilizzatori del servizio qualificandolo come responsabile del trattamento in ottemperanza al GDPR"
     },
     "hotspot": {
       "yes": "Sì",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -197,7 +197,7 @@
       "wifi4eu_zdebug": "WiFi4EU Autotest",
       "wifi4eu_zdebug_desc": "La modalità autotest interrompe il corretto funzionamento dell'hotspot e va utilizzata solo per specifiche verifiche. Questa opzione in condizioni normali deve essere sempre disabilitata.",
       "warning_privacy": "Attenzione",
-      "warning_privacy_text": "Attenzione text",
+      "warning_privacy_text": "È necessario compilare i dati reseller prima di procedere",
       "profile_link": "Profilo link"
     },
     "user": {

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -47,7 +47,8 @@
       "privacy_address": "Indirizzo",
       "privacy_email": "Email per comunicazioni privacy",
       "privacy_dpo": "Nome del DPO (opzionale)",
-      "privacy_dpo_mail": "Email del DPO (opzionale)"
+      "privacy_dpo_mail": "Email del DPO (opzionale)",
+      "privacy_info": "Privacy info here"
     },
     "hotspot": {
       "yes": "Sì",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -46,7 +46,7 @@
       "privacy_vat": "Partita IVA/CF",
       "privacy_address": "Indirizzo",
       "privacy_email": "Email per comunicazioni privacy",
-      "privacy_dpo": "NOme del DPO (opzionale)",
+      "privacy_dpo": "Nome del DPO (opzionale)",
       "privacy_dpo_mail": "Email del DPO (opzionale)"
     },
     "hotspot": {

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -40,7 +40,14 @@
       "default_disclaimer": "Disclaimer di default",
       "privacy_disclaimer": "Disclaimer Privacy",
       "tos_disclaimer": "Disclaimer Termini di utilizzo",
-      "default": "Default"
+      "default": "Default",
+      "privacy_fields": "Privacy fields",
+      "privacy_name": "Reseller's business name",
+      "privacy_vat": "Reseller's business VAT",
+      "privacy_address": "Reseller's business address",
+      "privacy_email": "Reseller's business email",
+      "privacy_dpo": "Reseller's business DPO (optional)",
+      "privacy_dpo_mail": "Reseller's business DPO email (optional)"
     },
     "hotspot": {
       "yes": "Sì",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -48,7 +48,7 @@
       "privacy_email": "Email per comunicazioni privacy",
       "privacy_dpo": "Nome del DPO (opzionale)",
       "privacy_dpo_mail": "Email del DPO (opzionale)",
-      "privacy_info": "Privacy info here"
+      "privacy_info": "I dati del rivenditore inseriti in questa sezione saranno usati per compilare l'informativa privacy visualizzata agli utilizzatori del servizio qualificandolo come responsabile del trattamento in ottemperanza al GDPR."
     },
     "hotspot": {
       "yes": "Sì",

--- a/sun/sun-ui/src/i18n/locale-it.json
+++ b/sun/sun-ui/src/i18n/locale-it.json
@@ -198,7 +198,7 @@
       "wifi4eu_zdebug_desc": "La modalità autotest interrompe il corretto funzionamento dell'hotspot e va utilizzata solo per specifiche verifiche. Questa opzione in condizioni normali deve essere sempre disabilitata.",
       "warning_privacy": "Attenzione",
       "warning_privacy_text": "È necessario compilare i dati reseller prima di procedere",
-      "profile_link": "Profilo link"
+      "profile_link": "Link al profilo reseller"
     },
     "user": {
       "username": "Utente",

--- a/sun/sun-ui/src/styles/main.css
+++ b/sun/sun-ui/src/styles/main.css
@@ -483,3 +483,9 @@ a {
 .adjust-icon-size {
   font-size: 17px !important;
 }
+
+.create-hotspot-warning {
+  float: right;
+  margin-right: 170px;
+  margin-top: -56px;
+}

--- a/wax/methods/privacy.go
+++ b/wax/methods/privacy.go
@@ -38,6 +38,7 @@ import (
 func GetPrivacies(c *gin.Context) {
 	hotspotUuid := c.Param("hotspot_uuid")
 	hotspot := utils.GetHotspotByUuid(hotspotUuid)
+	account := utils.GetAccountByAccountId(hotspot.AccountId)
 
 	if hotspot.Id == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"id": hotspot.Id, "status": "hotspot not found"})
@@ -101,7 +102,7 @@ func GetPrivacies(c *gin.Context) {
 		var marketingMessage bytes.Buffer
 		m := template.Must(template.New("marketings").Parse(privacyDisclaimers[idx].Body))
 
-		errM := m.Execute(&marketingMessage, &hotspot)
+		errM := m.Execute(&marketingMessage, &account)
 		if errM != nil {
 			fmt.Println(errM)
 		}

--- a/wax/methods/wings.go
+++ b/wax/methods/wings.go
@@ -105,11 +105,11 @@ func GetWingsPrefs(c *gin.Context) {
 	t := template.Must(template.New("terms").Parse(terms))
 	m := template.Must(template.New("marketings").Parse(marketings))
 
-	errT := t.Execute(&termsMessage, &account)
+	errT := t.Execute(&termsMessage, &hotspot)
 	if errT != nil {
 		fmt.Println(errT)
 	}
-	errM := m.Execute(&marketingMessage, &hotspot)
+	errM := m.Execute(&marketingMessage, &account)
 	if errM != nil {
 		fmt.Println(errM)
 	}

--- a/wax/methods/wings.go
+++ b/wax/methods/wings.go
@@ -49,6 +49,9 @@ func GetWingsPrefs(c *gin.Context) {
 	// extract hotspot info
 	hotspot := utils.GetHotspotById(unit.HotspotId)
 
+	// extract account info
+	account := utils.GetAccountByAccountId(hotspot.AccountId)
+
 	// get hotspot preferences
 	prefs := utils.GetHotspotPreferences(hotspot.Id)
 
@@ -102,7 +105,7 @@ func GetWingsPrefs(c *gin.Context) {
 	t := template.Must(template.New("terms").Parse(terms))
 	m := template.Must(template.New("marketings").Parse(marketings))
 
-	errT := t.Execute(&termsMessage, &hotspot)
+	errT := t.Execute(&termsMessage, &account)
 	if errT != nil {
 		fmt.Println(errT)
 	}


### PR DESCRIPTION
To comply with the new GDPR and Privacy regulations, portal accounts are required to enter some important information.

This PR adds the ability to insert fields into the account profile and prevents the creation of new hotspots if these fields are not filled in.

After merge execute:
```sql
ALTER TABLE accounts ADD `privacy_name` varchar(512) AFTER `email`;
ALTER TABLE accounts ADD `privacy_vat` varchar(512) AFTER `privacy_name`;
ALTER TABLE accounts ADD `privacy_address` varchar(512) AFTER `privacy_vat`;
ALTER TABLE accounts ADD `privacy_email` varchar(512) AFTER `privacy_address`;
ALTER TABLE accounts ADD `privacy_dpo` varchar(512) AFTER `privacy_email`;
ALTER TABLE accounts ADD `privacy_dpo_mail` varchar(512) AFTER `privacy_dpo`;
```